### PR TITLE
Update Development Script to match refactored Production.sh

### DIFF
--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -177,7 +177,7 @@ if ! [[ $* = *--zombie* ]]; then
   echo "Configuration Complete, you can watch annealing from the UI.  \`su - crowbar\` to begin managing the system."
   # Converge the admin node.
   crowbar converge && date
-  echo "Could not converge all noderoles!"
+  echo "Did not converge all noderoles before timeout (this may be ok)."
 else
   echo "To complete configuration, mark node alive using: crowbar nodes update 1 '{""alive"": true}'"
 fi

--- a/crowbar-core.sh
+++ b/crowbar-core.sh
@@ -26,7 +26,9 @@ EOF
 fi
 . ./bootstrap.sh
 
-export RAILS_ENV=production
+if [[ ! $RAILS_ENV ]]; then
+	export RAILS_ENV=$1
+fi
 
 . /etc/profile
 ./setup/00-crowbar-rake-tasks.install && \

--- a/production.sh
+++ b/production.sh
@@ -29,5 +29,5 @@ fi
 ./crowbar-boot.sh
 ./crowbar-consul.sh
 ./crowbar-database.sh
-./crowbar-core.sh
+./crowbar-core.sh "$RAILS_ENV"
 ./crowbar-config.sh "$@"


### PR DESCRIPTION
Development.sh needed to match the new layout for Production.sh

To make the subscripts work, I had to pass in production|development instead of having it hard coded.