### PR TITLE
fixing #376: saltstack install on centos7, centos6.6

### DIFF
--- a/script/roles/saltstack-master/01-install-master.sh
+++ b/script/roles/saltstack-master/01-install-master.sh
@@ -28,6 +28,7 @@ fi
 
 if ! which salt-master; then
     if [[ -f /etc/redhat-release || -f /etc/centos-release ]]; then
+        yum install -y epel-release  # tested to work on cent 6.5, 6.6, and 7.0 as of 01/19/2015
         yum -y makecache
         yum install -y GitPython
         yum install -y salt-master

--- a/script/roles/saltstack-minion/01-install-minion.sh
+++ b/script/roles/saltstack-minion/01-install-minion.sh
@@ -37,6 +37,7 @@ fi
 # Install salt-minion
 if ! which salt-minion; then
     if [[ -f /etc/redhat-release || -f /etc/centos-release ]]; then
+        yum install -y epel-release  # tested to work on cent 6.5, 6.6, and 7.0 as of 01/19/2015
         yum -y makecache
         yum install -y salt-minion
         chkconfig salt-minion on


### PR DESCRIPTION
Tested the change on some centos7 on baremetal and centos 6.6/6.5 in virtualbox (chef boxes with vagrant)

This resolved #376
