### PR TITLE
Don't print a bad message on converge completion.  It already does.

### DIFF
--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -185,7 +185,6 @@ if ! [[ $* = *--zombie* ]]; then
   echo "Configuration Complete, you can watch annealing from the UI.  \`su - crowbar\` to begin managing the system."
   # Converge the admin node.
   crowbar converge && date
-  echo "Did not converge all noderoles before timeout (this may be ok)."
 else
   echo "To complete configuration, mark node alive using: crowbar nodes update 1 '{""alive"": true}'"
 fi

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -149,6 +149,7 @@ class NodeRolesController < ApplicationController
         elsif NodeRole.committed.in_state(NodeRole::TRANSITION).count > 0
           render :json => { "message" => "working" }, :status => 202
         elsif NodeRole.committed.in_state(NodeRole::ERROR).count > 0
+          Rails.logger.info("Failed node roles: #{NodeRole.committed.in_state(NodeRole::ERROR).inspect}")
           render :json => { "message" => "failed" }, :status => 409
         else
           render :json => { "message" => "finished" }, :state => 200


### PR DESCRIPTION
Add a log to indicated errored node roles.