### PR TITLE
Service cleanup

### DIFF
--- a/BDD/node.erl
+++ b/BDD/node.erl
@@ -31,23 +31,24 @@ g(Item) ->
     deployment -> "system";
     _ -> crowbar:g(Item)
   end.
-  
+
 % Common Routine
 % Makes sure that the JSON conforms to expectations (only tests deltas)
 validate(JSON) when is_record(JSON, obj) ->
   J = JSON#obj.data,
   R =[JSON#obj.type == "node",
-      bdd_utils:is_a(J, length, 17),
-      bdd_utils:is_a(J, boolean, alive), 
-      bdd_utils:is_a(J, boolean, available), 
-      bdd_utils:is_a(J, boolean, allocated), 
-      bdd_utils:is_a(J, boolean, admin), 
-      bdd_utils:is_a(J, string, bootenv), 
-      bdd_utils:is_a(J, string, discovery), 
-      bdd_utils:is_a(J, string, hint), 
-      bdd_utils:is_a(J, dbid, deployment_id), 
+      bdd_utils:is_a(J, length, 18),
+      bdd_utils:is_a(J, boolean, alive),
+      bdd_utils:is_a(J, boolean, system),
+      bdd_utils:is_a(J, boolean, available),
+      bdd_utils:is_a(J, boolean, allocated),
+      bdd_utils:is_a(J, boolean, admin),
+      bdd_utils:is_a(J, string, bootenv),
+      bdd_utils:is_a(J, string, discovery),
+      bdd_utils:is_a(J, string, hint),
+      bdd_utils:is_a(J, dbid, deployment_id),
       bdd_utils:is_a(J, dbid, target_role_id),
-      bdd_utils:is_a(J, string, alias), 
+      bdd_utils:is_a(J, string, alias),
       bdd_utils:is_a(J, integer, order),
       crowbar_rest:validate(J)],
   bdd_utils:assert(R).

--- a/barclamps/crowbar.yml
+++ b/barclamps/crowbar.yml
@@ -23,7 +23,6 @@ roles:
       - implicit
     requires:
       - network-server
-      - dns-database
       - provisioner-dhcp-database
       - provisioner-repos
       - provisioner-docker-setup

--- a/barclamps/dns.yml
+++ b/barclamps/dns.yml
@@ -19,15 +19,6 @@ roles:
     requires:
       - network-admin
     attribs:
-      - name: dns_servers
-        description: 'DNS servers that all Crowbar clients should use'
-        map: 'crowbar/dns/nameservers'
-      - name: dns-domain
-        description: 'DNS domain name for the cluster'
-        map: 'crowbar/dns/domain'
-      - name: dns-all
-        description: 'All the DNS attributes in one internally useful block'
-        map: 'crowbar/dns'
       - name: dns-forwarders
         description: 'DNS servers that Crowbar will use for recursive queries'
         map: 'crowbar/dns/forwarders'
@@ -38,17 +29,52 @@ roles:
               pattern: /[0-9a-f:.]*/
   - name: dns-database
     jig: chef
-    flags:
     requires:
       - dns-server
-    wants-attribs:
-      - dns-all
+  - name: dns-service
+    jig: role-provided
+    flags:
+      - service
+    attribs:
+      - name: dns_servers
+        description: 'DNS servers that all Crowbar clients should use'
+        map: 'crowbar/dns/nameservers'
+        schema:
+          type: seq
+          sequence:
+            - type: str
+              pattern: /[0-9a-f:.]*/
+      - name: dns-domain
+        description: 'DNS domain name for the cluster'
+        map: 'crowbar/dns/domain'
+        schema:
+          type: str
+          required: true
   - name: dns-client
     jig: chef
     flags:
       - implicit
     requires:
-      - dns-server
+      - dns-service
       - network-admin
     wants-attribs:
       - dns_servers
+      - dns-domain
+  - name: dns-mgmt_service
+    jig: role-provided
+    flags:
+      - service
+    attribs:
+      - name: dns_shm_servers
+        description: 'DNS Shim servers that all Crowbar admins should use'
+        map: 'crowbar/dns/shimservers'
+  - name: dns-mgmt_shim_provider
+    jig: noop
+  - name: dns-mgmt_shim_crowbar_dns
+    jig: chef
+    provides:
+      - dns-mgmt_shim_provider
+  - name: dns-mgmt_shim_power_dns
+    jig: script
+    provides:
+      - dns-mgmt_shim_provider

--- a/barclamps/dns.yml
+++ b/barclamps/dns.yml
@@ -18,6 +18,7 @@ roles:
     jig: chef
     requires:
       - network-admin
+      - consul
     attribs:
       - name: dns-forwarders
         description: 'DNS servers that Crowbar will use for recursive queries'

--- a/barclamps/ntp.yml
+++ b/barclamps/ntp.yml
@@ -16,18 +16,39 @@
 roles:
   - name: ntp-server
     jig: chef
+    provides:
+      - ntp-client
     requires:
       - dns-client
       - network-admin
+      - consul
+    attribs:
+      - name: ntp_servers_external
+        description: "Addresses of the external NTP servers to use for upstream time synchronization"
+        map: 'crowbar/ntp/external_servers'
+        schema:
+          type: seq
+          sequence:
+            - type: str
+              pattern: /[0-9a-f:.]*/
+  - name: ntp-service
+    jig: role-provided
+    flags:
+      - service
     attribs:
       - name: ntp_servers
         description: "Addresses of the NTP servers to use for cluster-wide time synchronization"
         map: 'crowbar/ntp/servers'
+        schema:
+          type: seq
+          sequence:
+            - type: str
+              pattern: /[0-9a-f:.]*/
   - name: ntp-client
     jig: chef
     requires:
       - dns-client
-      - ntp-server
+      - ntp-service
       - network-admin
     flags:
       - implicit

--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -19,7 +19,7 @@ roles:
       - network-admin
       - dns-client
       - logging-server
-      - ntp-server
+      - ntp-client
     attribs:
       - name: provisioner-machine_key
         description: 'The username and password that managed nodes should use to talk to the Crowbar API'

--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -83,11 +83,15 @@ roles:
       - provisioner-online
   - name: provisioner-dhcp-server
     jig: chef
+    wants-attribs:
+      - dns_servers
     requires:
       - provisioner-server
       - provisioner-base-images
   - name: provisioner-dhcp-database
     jig: chef
+    wants-attribs:
+      - dns_servers
     requires:
       - provisioner-dhcp-server
   - name: provisioner-docker-setup

--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -85,3 +85,16 @@ template "/etc/named.conf" do
   variables(:forwarders => node[:crowbar][:dns][:forwarders])
   notifies :restart, "service[bind9]", :immediately
 end
+
+bash "reload consul" do
+  code "/usr/local/bin/consul reload"
+  action :nothing
+end
+
+template "/etc/consul.d/crowbar-dns.json" do
+  source "consul-dns-server.json.erb"
+  mode 0644
+  owner "root"
+  notifies :run, "bash[reload consul]", :immediately
+end
+

--- a/chef/cookbooks/bind9/templates/default/consul-dns-server.json.erb
+++ b/chef/cookbooks/bind9/templates/default/consul-dns-server.json.erb
@@ -1,0 +1,1 @@
+{"service": {"name": "dns-service", "tags": [], "port": 42}}

--- a/chef/cookbooks/bind9/templates/default/consul-dns-server.json.erb
+++ b/chef/cookbooks/bind9/templates/default/consul-dns-server.json.erb
@@ -1,1 +1,1 @@
-{"service": {"name": "dns-service", "tags": [], "port": 42}}
+{"service": {"name": "dns-service", "tags": [ "system" ], "port": 42}}

--- a/chef/cookbooks/bind9/templates/default/consul-dns-server.json.erb
+++ b/chef/cookbooks/bind9/templates/default/consul-dns-server.json.erb
@@ -1,1 +1,11 @@
-{"service": {"name": "dns-service", "tags": [ "system" ], "port": 42}}
+{
+  "service": {
+    "name": "dns-service",
+    "tags": [ "system" ],
+    "port": 42,
+    "check": {
+      "script": "dig @127.0.0.1 127.0.0.1 >/dev/null 2>&1",
+      "interval": "10s"
+    }
+  }
+}

--- a/chef/cookbooks/consul/attributes/default.rb
+++ b/chef/cookbooks/consul/attributes/default.rb
@@ -35,4 +35,4 @@ default[:consul][:servers] = []
 # UI attributes
 default[:consul][:client_addr] = '0.0.0.0'
 default[:consul][:ui_dir] = '/var/lib/consul/ui'
-default[:consul][:serve_ui] = false
+default[:consul][:serve_ui] = true

--- a/chef/cookbooks/dhcp/metadata.rb
+++ b/chef/cookbooks/dhcp/metadata.rb
@@ -5,4 +5,6 @@ license          "Apache 2.0"
 description      "Maintains DHCP server for Crowbar"
 long_description "Maintains DHCP server for Crowbar"
 version          "1.0.0"
+depends           "utils"
+depends           "bind9"
 

--- a/chef/cookbooks/dhcp/recipes/default.rb
+++ b/chef/cookbooks/dhcp/recipes/default.rb
@@ -14,6 +14,7 @@
 #
 
 include_recipe "utils"
+include_recipe "bind9::install"
 
 provisioner_port = (node["crowbar"]["provisioner"]["server"]["web_port"] rescue 8091)
 

--- a/chef/cookbooks/ntp/templates/default/consul-ntp-server.json.erb
+++ b/chef/cookbooks/ntp/templates/default/consul-ntp-server.json.erb
@@ -1,1 +1,11 @@
-{"service": {"name": "ntp-service", "tags": [ "system" ], "port": 123}}
+{
+  "service": {
+    "name": "ntp-service",
+    "tags": [ "system" ],
+    "port": 123,
+    "check": {
+      "script": "ntpdate -q 127.0.0.1 2>&1 >/dev/null",
+      "interval": "10s"
+    }
+  }
+}

--- a/chef/cookbooks/ntp/templates/default/consul-ntp-server.json.erb
+++ b/chef/cookbooks/ntp/templates/default/consul-ntp-server.json.erb
@@ -1,0 +1,1 @@
+{"service": {"name": "ntp-service", "tags": [ "system" ], "port": 123}}

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -129,28 +129,15 @@ admin_node="
   \"bootenv\": \"local\"
 }
 "
-system_node="
-{
-  \"name\": \"crowbar-system.$DOMAINNAME\",
-  \"admin\": false,
-  \"alive\": false,
-  \"system\": true,
-  \"bootenv\": \"local\"
-}
-"
-
 
 ###
 # This should vanish once we have a real bootstrapping story.
 ###
 ip_re='([0-9a-f.:]+/[0-9]+)'
 
-# Create system node
-crowbar nodes create "$system_node"
-
 # Add required or desired services
-crowbar roles bind dns-service to "crowbar-system.$DOMAINNAME"
-crowbar roles bind dns-mgmt_service to "crowbar-system.$DOMAINNAME"
+crowbar roles bind dns-service to "system-phantom.internal.local"
+crowbar roles bind dns-mgmt_service to "system-phantom.internal.local"
 
 # Set the domain name to use to the derived one
 ROLE_ID=`crowbar roles show dns-service | grep '"id"'`
@@ -161,7 +148,7 @@ NODE_ROLE_ID=${NODE_ROLE_ID##*:}
 NODE_ROLE_ID=${NODE_ROLE_ID%,}
 crowbar noderoles set $NODE_ROLE_ID attrib dns-domain to "{ \"value\": \"$DOMAINNAME\" }"
 
-crowbar nodes commit "crowbar-system.$DOMAINNAME"
+crowbar nodes commit "system-phantom.internal.local"
 
 # Create a stupid default admin network
 crowbar networks create "$admin_net"
@@ -208,8 +195,6 @@ done
 # Make sure that Crowbar is running with the proper environment variables
 service crowbar stop
 service crowbar start
-
-crowbar nodes update "crowbar-system.$DOMAINNAME" '{"alive": true}'
 
 # flag allows you to stop before final step
 if ! [[ $* = *--zombie* ]]; then

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -169,7 +169,16 @@ crowbar nodes create "$admin_node"
 # crowbar roles bind dns-mgmt_shim_crowbar_dns to "$FQDN"
 crowbar roles bind dns-database to "$FQDN"
 
+# Example external dns server - use instead of dns-database above
+#curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "209.18.47.61", "Service": {"Service": "dns-service", "Port": 43, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+
+# Ntp Service configuration
+# Use the admin node as the ntp server for the cluster
 crowbar roles bind ntp-server to "$FQDN"
+
+# Example external ntp server - use instead of ntp-server above
+#curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "pool.ntp.org", "Service": {"Service": "ntp-service", "Port": 123, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+
 
 crowbar roles bind crowbar-admin-node to "$FQDN"
 crowbar nodes commit "$FQDN"

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -129,11 +129,26 @@ admin_node="
   \"bootenv\": \"local\"
 }
 "
+system_node="
+{
+  \"name\": \"crowbar-system.$DOMAINNAME\",
+  \"admin\": false,
+  \"alive\": false,
+  \"system\": true,
+  \"bootenv\": \"local\"
+}
+"
+
 
 ###
 # This should vanish once we have a real bootstrapping story.
 ###
 ip_re='([0-9a-f.:]+/[0-9]+)'
+
+# Create system node
+crowbar nodes create "$system_node"
+
+crowbar nodes commit "crowbar-system.$DOMAINNAME"
 
 # Create a stupid default admin network
 crowbar networks create "$admin_net"
@@ -173,6 +188,8 @@ done
 # Make sure that Crowbar is running with the proper environment variables
 service crowbar stop
 service crowbar start
+
+crowbar nodes update "crowbar-system.$DOMAINNAME" '{"alive": true}'
 
 # flag allows you to stop before final step
 if ! [[ $* = *--zombie* ]]; then

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -137,6 +137,7 @@ ip_re='([0-9a-f.:]+/[0-9]+)'
 
 # Add required or desired services
 crowbar roles bind dns-service to "system-phantom.internal.local"
+crowbar roles bind ntp-service to "system-phantom.internal.local"
 crowbar roles bind dns-mgmt_service to "system-phantom.internal.local"
 
 # Set the domain name to use to the derived one
@@ -167,6 +168,8 @@ crowbar nodes create "$admin_node"
 # crowbar roles bind dns-server to "$FQDN"
 # crowbar roles bind dns-mgmt_shim_crowbar_dns to "$FQDN"
 crowbar roles bind dns-database to "$FQDN"
+
+crowbar roles bind ntp-server to "$FQDN"
 
 crowbar roles bind crowbar-admin-node to "$FQDN"
 crowbar nodes commit "$FQDN"

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -148,6 +148,19 @@ ip_re='([0-9a-f.:]+/[0-9]+)'
 # Create system node
 crowbar nodes create "$system_node"
 
+# Add required or desired services
+crowbar roles bind dns-service to "crowbar-system.$DOMAINNAME"
+crowbar roles bind dns-mgmt_service to "crowbar-system.$DOMAINNAME"
+
+# Set the domain name to use to the derived one
+ROLE_ID=`crowbar roles show dns-service | grep '"id"'`
+ROLE_ID=${ROLE_ID##*:}
+ROLE_ID=${ROLE_ID%,}
+NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 1' | grep \"id\"`
+NODE_ROLE_ID=${NODE_ROLE_ID##*:}
+NODE_ROLE_ID=${NODE_ROLE_ID%,}
+crowbar noderoles set $NODE_ROLE_ID attrib dns-domain to "{ \"value\": \"$DOMAINNAME\" }"
+
 crowbar nodes commit "crowbar-system.$DOMAINNAME"
 
 # Create a stupid default admin network
@@ -161,6 +174,13 @@ crowbar nodes create "$admin_node"
 
 # Bind the admin role to it, and commit the resulting
 # proposed noderoles.
+
+# TODO: One day do it this way:
+# Setup DNS Server and Mgmt Shim for our own DNS Server
+# crowbar roles bind dns-server to "$FQDN"
+# crowbar roles bind dns-mgmt_shim_crowbar_dns to "$FQDN"
+crowbar roles bind dns-database to "$FQDN"
+
 crowbar roles bind crowbar-admin-node to "$FQDN"
 crowbar nodes commit "$FQDN"
 

--- a/etc/init.d/crowbar
+++ b/etc/init.d/crowbar
@@ -52,16 +52,19 @@ start(){
     as_crowbar bundle exec puma -d -C $PUMA_CFG
     echo "Starting delayed_job NodeRoleRunner queue (10 workers)"
     as_crowbar bundle exec script/delayed_job --queue=NodeRoleRunner -n 10 start
+    as_crowbar bundle exec script/dj_reaper start
 }
 
 stop() {
     as_crowbar bundle exec pumactl -F $PUMA_CFG stop
     as_crowbar bundle exec script/delayed_job stop
+    as_crowbar bundle exec script/dj_reaper stop
 }
 
 restart() {
     as_crowbar bundle exec pumactl -F $PUMA_CFG restart
     as_crowbar bundle exec script/delayed_job restart
+    as_crowbar bundle exec script/dj_reaper restart
 }
 
 status() {

--- a/rails/app/controllers/network_routers_controller.rb
+++ b/rails/app/controllers/network_routers_controller.rb
@@ -1,0 +1,39 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class NetworkRoutersController < ::ApplicationController
+  respond_to :json
+
+  def index
+    @list = if params.has_key? :network_id or params.has_key? :network
+              network =  Network.find_key params[:network_id] || params[:network]
+              [ network.router ]
+            else
+              NetworkRouter.all
+            end
+    respond_to do |format|
+      format.json { render api_index NetworkRouter, @list }
+    end
+  end
+
+  def show
+    network = Network.find_key params[:network_id]
+    data = [ network.router.address.to_s ]
+    respond_to do |format|
+      format.json { render :json => data }
+    end
+  end
+
+end
+

--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -129,6 +129,7 @@ class NodesController < ApplicationController
                                          :deployment_id,
                                          :allocated,
                                          :alive,
+                                         :system,
                                          :available,
                                          :bootenv))
       # Keep suport for mac and ip hints in short form around for legacy Sledgehammer purposes

--- a/rails/app/models/barclamp_chef/server.rb
+++ b/rails/app/models/barclamp_chef/server.rb
@@ -16,7 +16,8 @@
 class BarclampChef::Server < Role
 
   def sysdata(nr)
-    addr = nr.node.addresses.detect{|addr|addr.v4?}.addr
+    addr = nr.node.addresses.detect{|a|a.v4?}
+    addr = addr.addr if addr
     port = Attrib.get("chef-server_port",nr.role)
     protocol = Attrib.get("chef-server_protocol",nr.role)
     { "chefjig" => {

--- a/rails/app/models/barclamp_dns/mgmt_service.rb
+++ b/rails/app/models/barclamp_dns/mgmt_service.rb
@@ -1,0 +1,21 @@
+# Copyright 2015, Greg Althaus
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+class BarclampDns::MgmtService < Role
+
+  def do_transition(nr,data)
+  end
+
+end

--- a/rails/app/models/barclamp_dns/mgmt_shim_crowbar_dns.rb
+++ b/rails/app/models/barclamp_dns/mgmt_shim_crowbar_dns.rb
@@ -1,0 +1,59 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+class BarclampDns::MgmtShimCrowbarDns < Role
+
+
+  def on_node_create(n)
+    Rails.logger.info("dns-database: Updating for new node #{n.name}")
+    rerun_my_noderoles
+  end
+
+  def on_node_change(n)
+    rerun_my_noderoles
+  end
+
+  def on_node_delete(n)
+    rerun_my_noderoles
+  end
+
+  private
+
+  def rerun_my_noderoles
+    hosts = {}
+    to_enqueue = []
+    ActiveRecord::Base.connection.execute("select name, cname, address
+                                           from dns_database
+                                           where network = 'admin'").each do |row|
+      name, addr, cname = row["name"] + ".", IP.coerce(row["address"]), row["cname"]
+      hosts[name] ||= Hash.new
+      hosts[name][addr.v4? ? "ip4addr" : "ip6addr"] ||= addr.addr
+      hosts[name][cname] ||= cname if cname && !name.index(cname)
+    end
+    node_roles.each do |nr|
+      nr.with_lock('FOR NO KEY UPDATE') do
+        old_hosts = (nr.sysdata["crowbar"]["dns"]["hosts"] rescue {})
+        if hosts == old_hosts
+          Rails.logger.info("dns-database: DNS information unchanged.")
+          next
+        end
+        Rails.logger.info("dns-database: Updating #{nr.name}")
+        nr.update_column("sysdata", {"crowbar" => {"dns" => {"hosts" => hosts}}})
+        to_enqueue << nr
+      end
+    end
+    to_enqueue.each {|nr| Run.enqueue(nr)}
+  end
+end

--- a/rails/app/models/barclamp_dns/service.rb
+++ b/rails/app/models/barclamp_dns/service.rb
@@ -1,0 +1,56 @@
+# Copyright 2015, Greg Althaus
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+class BarclampDns::Service < Role
+
+  def do_transition(nr,data)
+    runlog = []
+    addr_arr = []
+    runlog << "Getting dns-service information from consul"
+    pieces = nil
+    options = {}
+    meta = {}
+    while pieces == nil
+      begin
+        pieces = Diplomat::Service.get("dns-service", :all, options, meta)
+        if pieces and pieces.empty?
+          runlog << "dns-service not availabe ... wait 10m or next update"
+          if meta[:index]
+            options[:wait] = "10m"
+            options[:index] = meta[:index]
+          else
+            sleep 1
+          end
+          pieces = nil
+        end
+      rescue Exception => e
+        runlog << "Failed to talk to consul: #{e.message}"
+        nr.runlog = runlog.join("\n")
+        sleep 1
+      end
+    end
+
+    runlog << "Processing pieces"
+    pieces.each do |p|
+      addr_arr << p.Address
+    end
+
+    runlog << "Setting dns-service attribute"
+    Attrib.set("dns_servers", nr, addr_arr, :system)
+    nr.runlog = runlog.join("\n")
+    raise "dns-service not available" if pieces.empty?
+  end
+
+end

--- a/rails/app/models/barclamp_ntp/service.rb
+++ b/rails/app/models/barclamp_ntp/service.rb
@@ -13,12 +13,12 @@
 # limitations under the License. 
 # 
 
-class BarclampDns::Service < Role
+class BarclampNtp::Service < Role
 
   def do_transition(nr,data)
     runlog = []
     addr_arr = []
-    runlog << "Getting dns-service information from consul"
+    runlog << "Getting ntp-service information from consul"
     pieces = nil
     options = {}
     meta = {}
@@ -27,10 +27,10 @@ class BarclampDns::Service < Role
       begin
         count += 1
         break if count > 20
-        pieces = Diplomat::Service.get("dns-service", :all, options, meta)
+        pieces = Diplomat::Service.get("ntp-service", :all, options, meta)
         if pieces and pieces.empty?
-          Rails.logger.info("dns-service not available ... wait 10m or next update")
-          runlog << "dns-service not available ... wait 10m or next update"
+          Rails.logger.info("ntp-service not available ... wait 10m or next update")
+          runlog << "ntp-service not available ... wait 10m or next update"
           if meta[:index]
             options[:wait] = "10m"
             options[:index] = meta[:index]
@@ -39,8 +39,8 @@ class BarclampDns::Service < Role
           end
           pieces = nil
         elsif pieces == nil
-          Rails.logger.info("dns-service not found ... wait 10s")
-          runlog << "dns-service not found ... wait 10s"
+          Rails.logger.info("ntp-service not found ... wait 10s")
+          runlog << "ntp-service not found ... wait 10s"
           sleep 10
         end
       rescue Exception => e
@@ -55,13 +55,13 @@ class BarclampDns::Service < Role
       pieces.each do |p|
         addr_arr << p.Address
       end
-      runlog << "Setting dns-service attribute"
-      Attrib.set("dns_servers", nr, addr_arr, :system)
+      runlog << "Setting ntp-service attribute"
+      Attrib.set("ntp_servers", nr, addr_arr, :system)
     end
 
-    Rails.logger.info("Finished waiting for dns-service: #{addr_arr.length} found")
+    Rails.logger.info("Finished waiting for ntp service: #{addr_arr.length} found")
     nr.runlog = runlog.join("\n")
-    raise "dns-service not available" if pieces == nil or pieces.empty?
+    raise "ntp-service not available" if pieces == nil or pieces.empty?
   end
 
 end

--- a/rails/app/models/barclamp_ntp/service.rb
+++ b/rails/app/models/barclamp_ntp/service.rb
@@ -13,55 +13,9 @@
 # limitations under the License. 
 # 
 
-class BarclampNtp::Service < Role
+class BarclampNtp::Service < Service
 
-  def do_transition(nr,data)
-    runlog = []
-    addr_arr = []
-    runlog << "Getting ntp-service information from consul"
-    pieces = nil
-    options = {}
-    meta = {}
-    count=0
-    while pieces == nil
-      begin
-        count += 1
-        break if count > 20
-        pieces = Diplomat::Service.get("ntp-service", :all, options, meta)
-        if pieces and pieces.empty?
-          Rails.logger.info("ntp-service not available ... wait 10m or next update")
-          runlog << "ntp-service not available ... wait 10m or next update"
-          if meta[:index]
-            options[:wait] = "10m"
-            options[:index] = meta[:index]
-          else
-            sleep 10
-          end
-          pieces = nil
-        elsif pieces == nil
-          Rails.logger.info("ntp-service not found ... wait 10s")
-          runlog << "ntp-service not found ... wait 10s"
-          sleep 10
-        end
-      rescue Exception => e
-        runlog << "Failed to talk to consul: #{e.message}"
-        Rails.logger.info("Failed to talk to consul: #{e.message}")
-        sleep 10
-      end
-    end
-
-    runlog << "Processing pieces"
-    if pieces
-      pieces.each do |p|
-        addr_arr << p.Address
-      end
-      runlog << "Setting ntp-service attribute"
-      Attrib.set("ntp_servers", nr, addr_arr, :system)
-    end
-
-    Rails.logger.info("Finished waiting for ntp service: #{addr_arr.length} found")
-    nr.runlog = runlog.join("\n")
-    raise "ntp-service not available" if pieces == nil or pieces.empty?
+  def do_transition(nr, data)
+    internal_do_transition(nr, data, "ntp-service", "ntp_servers")
   end
-
 end

--- a/rails/app/models/node.rb
+++ b/rails/app/models/node.rb
@@ -510,7 +510,6 @@ class Node < ActiveRecord::Base
 
   # make sure some safe values are set for the node
   def default_population
-    self.admin = true if Node.admin.count == 0    # first node, needs to be admin
     self.name = self.name.downcase
     self.alias ||= self.name.split(".")[0]
     self.deployment ||= Deployment.system

--- a/rails/app/models/node.rb
+++ b/rails/app/models/node.rb
@@ -136,7 +136,8 @@ class Node < ActiveRecord::Base
   end
 
   def addresses
-    net = Network.find_by!(:name => "admin")
+    net = Network.find_by!(:name => "admin") rescue nil
+    return [] unless net
     res = network_allocations.where(network_id: net.id).map do |a|
       a.address
     end

--- a/rails/app/models/service.rb
+++ b/rails/app/models/service.rb
@@ -1,0 +1,67 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.  
+
+class Service < Role
+
+  def internal_do_transition(nr, data, service_name, service_attribute)
+    runlog = []
+    addr_arr = []
+    runlog << "Getting #{service_name} information from consul"
+    pieces = nil
+    options = {}
+    meta = {}
+    count=0
+    while pieces == nil
+      begin
+        count += 1
+        break if count > 20
+        pieces = Diplomat::Service.get(service_name, :all, options, meta)
+        if pieces and pieces.empty?
+          Rails.logger.info("#{service_name} not available ... wait 10m or next update")
+          runlog << "#{service_name} not available ... wait 10m or next update"
+          if meta[:index]
+            options[:wait] = "10m"
+            options[:index] = meta[:index]
+          else
+            sleep 10
+          end
+          pieces = nil
+        elsif pieces == nil
+          Rails.logger.info("#{service_name} not found ... wait 10s")
+          runlog << "#{service_name} not found ... wait 10s"
+          sleep 10
+        end
+      rescue Exception => e
+        runlog << "Failed to talk to consul: #{e.message}"
+        Rails.logger.info("Failed to talk to consul: #{e.message}")
+        sleep 10
+      end
+    end
+
+    runlog << "Processing pieces for #{service_name}"
+    if pieces
+      pieces.each do |p|
+        addr_arr << p.Address
+      end
+      runlog << "Setting #{service_name} attribute"
+      Attrib.set(service_attribute, nr, addr_arr, :system)
+    end
+
+    Rails.logger.info("Finished waiting for #{service_name}: #{addr_arr.length} found")
+    nr.runlog = runlog.join("\n")
+    nr.save!
+    raise "#{service_name} not available" if pieces == nil or pieces.empty?
+  end
+
+end

--- a/rails/app/views/dashboard/getready.html.haml
+++ b/rails/app/views/dashboard/getready.html.haml
@@ -43,7 +43,7 @@
     %tbody
       - if @nodes and @nodes.count > 1
         - @nodes.sort_by{|n| n.name }.each do |node|
-          - unless node.is_admin?
+          - unless node.is_admin? or node.is_system?
             %tr.node{ :class => cycle(:odd, :even, :name => "nodes"), :id => node.id }
               %td= check_box_tag "node_#{node.id}", "include", !node.is_admin?
               %td.status

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -31,7 +31,7 @@ module Crowbar
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
@@ -92,6 +92,15 @@ module Crowbar
     CROWBAR_VERSION = '2.x' unless defined? CROWBAR_VERSION
     SERVER_PID = %x[ps ax | grep "puma" | grep -v grep].split(' ')[0]  # get a consistent number that changes when the server restarts
 
-    
+    config.jobs = ActiveSupport::OrderedOptions.new
+    # Controls whether or not workers report heartbeats
+    config.jobs.heartbeat_enabled = true
+    # How often workers should send heartbeats
+    config.jobs.heartbeat_interval_seconds = 15
+    # How long a worker can go without sending a heartbeat before they're considered dead
+    config.jobs.heartbeat_timeout_seconds = 3 * 15
+    # How often to check for dead workers
+    config.jobs.dead_worker_polling_interval_seconds = 15
+
   end
 end

--- a/rails/config/initializers/register_plugin.rb
+++ b/rails/config/initializers/register_plugin.rb
@@ -1,0 +1,2 @@
+require Rails.root.join('lib/delayed/heartbeat/plugin')
+Delayed::Worker.plugins << Delayed::Heartbeat::Plugin

--- a/rails/db/migrate/20140430000000_crowbar_anvil.rb
+++ b/rails/db/migrate/20140430000000_crowbar_anvil.rb
@@ -238,7 +238,7 @@ with recursive arrp (child_name, parent_name, path) as (
       t.boolean     :available,         null: false, default: true
       t.integer     :order,             default: 10000
       t.json        :proposed_data,     null: false, default: { expr: "'{}'::json" }
-      t.json        :committed_data,    null: true
+      t.json        :committed_data,    null: false, default: { expr: "'{}'::json" }
       t.json        :sysdata,           null: false, default: { expr: "'{}'::json" }
       t.json        :wall,              null: false, default: { expr: "'{}'::json" }
       t.timestamps

--- a/rails/db/migrate/20150104222800_add_system_flag_to_node.rb
+++ b/rails/db/migrate/20150104222800_add_system_flag_to_node.rb
@@ -1,0 +1,22 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class AddSystemFlagToNode < ActiveRecord::Migration
+  def change
+    change_table :nodes do |t|
+      t.boolean    :system,             null: false, default: false
+    end
+  end
+end

--- a/rails/db/migrate/20150120110800_create_delayed_workers.rb
+++ b/rails/db/migrate/20150120110800_create_delayed_workers.rb
@@ -1,0 +1,10 @@
+
+class CreateDelayedWorkers < ActiveRecord::Migration
+  def change
+    create_table(:delayed_workers) do |t|
+      t.string :name
+      t.timestamp :last_heartbeat_at
+    end
+    add_index(:delayed_workers, :name, unique: true)
+  end
+end

--- a/rails/lib/delayed/heartbeat/plugin.rb
+++ b/rails/lib/delayed/heartbeat/plugin.rb
@@ -1,0 +1,15 @@
+module Delayed
+  module Heartbeat
+    class Plugin < Delayed::Plugin
+      callbacks do |lifecycle|
+        lifecycle.before(:execute) do |worker|
+          @heartbeat = WorkerHeartbeat.new(worker.name) if Rails.configuration.jobs.heartbeat_enabled
+        end
+
+        lifecycle.after(:execute) do |worker|
+          @heartbeat.stop if @heartbeat
+        end
+      end
+    end
+  end
+end

--- a/rails/lib/delayed/heartbeat/worker_heartbeat.rb
+++ b/rails/lib/delayed/heartbeat/worker_heartbeat.rb
@@ -42,6 +42,7 @@ module Delayed
       def run_heartbeat_loop
         while true
           break if sleep_interruptibly(heartbeat_interval)
+          Rails.logger.info("Updating heartbeat: #{@worker_model.name}")
           @worker_model.update_heartbeat
         end
       rescue Exception => e

--- a/rails/lib/delayed/heartbeat/worker_heartbeat.rb
+++ b/rails/lib/delayed/heartbeat/worker_heartbeat.rb
@@ -1,0 +1,68 @@
+module Delayed
+  module Heartbeat
+    class WorkerHeartbeat
+
+      def initialize(worker_name)
+        @worker_model = create_worker_model(worker_name)
+
+        # Use a self-pipe to safely shutdown the heartbeat thread
+        @stop_reader, @stop_writer = IO.pipe
+
+        @heartbeat_thread = Thread.new { run_heartbeat_loop }
+        # We don't want the worker to continue running if the
+        # heartbeat can't be written
+        @heartbeat_thread.abort_on_exception = true
+      end
+
+      def alive?
+        @heartbeat_thread.alive?
+      end
+
+      def stop
+        # Use the self-pipe to tell the heartbeat thread to cleanly
+        # shutdown
+        if @stop_writer
+          @stop_writer.write_nonblock('stop')
+          @stop_writer.close
+          @stop_writer = nil
+        end
+      end
+
+      private
+
+      def create_worker_model(worker_name)
+        WorkerModel.transaction do
+          # Just recreate the worker model to avoid the race condition where
+          # it gets deleted before we can update its last heartbeat
+          WorkerModel.where(name: worker_name).destroy_all
+          WorkerModel.create!(name: worker_name)
+        end
+      end
+
+      def run_heartbeat_loop
+        while true
+          break if sleep_interruptibly(heartbeat_interval)
+          @worker_model.update_heartbeat
+        end
+      rescue Exception => e
+        Rails.logger.error("Worker heartbeat error: #{e.message}: #{e.backtrace.join('\n')}")
+        raise e
+      ensure
+        Rails.logger.info('Shutting down worker heartbeat thread')
+        @stop_reader.close
+        @worker_model.delete
+        Delayed::Backend::ActiveRecord::Job.clear_active_connections!
+      end
+
+      def heartbeat_interval
+        Rails.configuration.jobs.heartbeat_interval_seconds
+      end
+
+      # Returns a truthy if the sleep was interrupted
+      def sleep_interruptibly(secs)
+        IO.select([@stop_reader], nil, nil, secs)
+      end
+
+    end
+  end
+end

--- a/rails/lib/delayed/heartbeat/worker_model.rb
+++ b/rails/lib/delayed/heartbeat/worker_model.rb
@@ -1,0 +1,31 @@
+module Delayed
+
+  module Heartbeat
+
+    class WorkerModel < ActiveRecord::Base
+
+      self.table_name = 'delayed_workers'
+
+      #attr_accessible :name, :last_heartbeat_at
+
+      before_create do |model|
+        model.last_heartbeat_at ||= Time.now.utc
+      end
+
+      def update_heartbeat
+        update_column(:last_heartbeat_at, Time.now.utc)
+      end
+
+      def self.dead_workers(timeout_seconds)
+        where('last_heartbeat_at < ?', Time.now.utc - timeout_seconds.seconds)
+      end
+
+      def self.active_names
+        select(:name)
+      end
+
+    end
+
+  end
+
+end

--- a/rails/lib/delayed/heartbeat_command.rb
+++ b/rails/lib/delayed/heartbeat_command.rb
@@ -64,6 +64,7 @@ module Delayed
       Delayed::Heartbeat::WorkerModel.dead_workers(timeout_seconds).delete_all
       orphaned_jobs = Delayed::Job.where("locked_at IS NOT NULL AND " \
                                          "locked_by NOT IN (#{Delayed::Heartbeat::WorkerModel.active_names.to_sql})")
+      Rails.logger.info("Unlocking the following jobs: #{orphaned_jobs.inspect}")
       orphaned_jobs.update_all('locked_at = NULL, locked_by = NULL, attempts = attempts + 1')
     end
 

--- a/rails/lib/delayed/heartbeat_command.rb
+++ b/rails/lib/delayed/heartbeat_command.rb
@@ -1,0 +1,71 @@
+unless ENV['RAILS_ENV'] == 'test'
+  begin
+    require 'daemons'
+  rescue LoadError
+    raise "You need to add gem 'daemons' to your Gemfile if you wish to use it."
+  end
+end
+require 'optparse'
+
+module Delayed
+  class HeartbeatCommand # rubocop:disable ClassLength
+    attr_accessor :worker_count, :worker_pools
+
+    def initialize(args) # rubocop:disable MethodLength
+      @options = {
+        :quiet => true,
+        :pid_dir => "#{Rails.root}/tmp/pids"
+      }
+
+      @worker_count = 1
+      @monitor = false
+
+      opts = OptionParser.new do |opt|
+        opt.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] start|stop|restart|run"
+
+        opt.on('-h', '--help', 'Show this message') do
+          puts opt
+          exit 1
+        end
+        opt.on('-e', '--environment=NAME', 'Specifies the environment to run this delayed jobs under (test/development/production).') do |_e|
+          STDERR.puts 'The -e/--environment option has been deprecated and has no effect. Use RAILS_ENV and see http://github.com/collectiveidea/delayed_job/issues/#issue/7'
+        end
+        opt.on('--pid-dir=DIR', 'Specifies an alternate directory in which to store the process ids.') do |dir|
+          @options[:pid_dir] = dir
+        end
+        opt.on('-m', '--monitor', 'Start monitor process.') do
+          @monitor = true
+        end
+      end
+      @args = opts.parse!(args)
+    end
+
+    def daemonize # rubocop:disable PerceivedComplexity
+      dir = @options[:pid_dir]
+      Dir.mkdir(dir) unless File.exist?(dir)
+
+      run_process("heartbeat.reaper", @options)
+    end
+
+    def run_process(process_name, options = {})
+      Delayed::Worker.before_fork
+      Daemons.run_proc(process_name, :dir => options[:pid_dir], :dir_mode => :normal, :monitor => @monitor, :ARGV => @args) do |*_args|
+        while true do
+          clear_workers
+          sleep Rails.configuration.jobs.dead_worker_polling_interval_seconds
+        end
+      end
+    end
+
+    private
+
+    def clear_workers
+      timeout_seconds = Rails.configuration.jobs.heartbeat_timeout_seconds
+      Delayed::Heartbeat::WorkerModel.dead_workers(timeout_seconds).delete_all
+      orphaned_jobs = Delayed::Job.where("locked_at IS NOT NULL AND " \
+                                         "locked_by NOT IN (#{Delayed::Heartbeat::WorkerModel.active_names.to_sql})")
+      orphaned_jobs.update_all('locked_at = NULL, locked_by = NULL, attempts = attempts + 1')
+    end
+
+  end
+end

--- a/rails/script/dj_reaper
+++ b/rails/script/dj_reaper
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/heartbeat_command'
+require 'delayed/heartbeat/plugin'
+require 'delayed/heartbeat/worker_model'
+Delayed::HeartbeatCommand.new(ARGV).daemonize


### PR DESCRIPTION
Includes dns-service and ntp-service pulls.

It creates a common routine for service management.
Adds health checks to the services.
Add examples and fixes for externalizing these two services.