### PR TITLE
allow roles to return async and stay in transition #396

### DIFF
--- a/BDD/bdd_catchall.erl
+++ b/BDD/bdd_catchall.erl
@@ -32,10 +32,12 @@ step(_Result, {_, _N, ["pause", Time, "seconds to", Message]}) ->
   {T, _} = string:to_integer(Time),
   io:format("\t\t\t...paused ~p seconds in order to ~s.~n", [T, Message]),
   timer:sleep(T*1000);
+step(_Result, {_S, _N, ["after 1 second"]}) -> step(_Result, {_S, _N, ["after", "1", "seconds"]});
 step(_Result, {_, _N, ["after", Time, "seconds"]}) -> 
   {T, _} = string:to_integer(Time),
   io:format("\t\t\tzzz...sleeping ~p seconds.~n", [T]),
   timer:sleep(T*1000);
+step(_Result, {_S, _N, ["after 1 minute"]}) -> step(_Result, {_S, _N, ["after", "1", "minutes"]});
 step(_Result, {_, _N, ["after", Time, "minutes"]}) -> 
   {T, _} = string:to_integer(Time),
   io:format("\t\t\tzzz...sleeping ~p minutes.~n", [T]),

--- a/BDD/features/async.feature
+++ b/BDD/features/async.feature
@@ -5,26 +5,30 @@ Feature: Async
 
   Scenario: Node goes to ready in 1 second
     Given REST creates the {object:node} "base.async.com"
-    When I sleep for 1 second
+    When after 1 second
     Then {object:node} "base.async.com" should not be in state "transition"
       And {object:node} "base.async.com" should not be in state "todo"
-      And {object:node} "base.async.com" should be in state "ready"
-    Finally I remove the {object:node} "base.async.com"
+      And {object:node} "base.async.com" should be in state "active"
+    Finally REST removes the {object:node} "base.async.com"
 
   Scenario: Async holds in transition
     Given REST creates the {object:node} "first.async.com"
-    When {object:node} "first.async.com" has the "test-async" role
-      And I sleep for 1 second
+      And {object:node} "first.async.com" has the "test-async" role
+    When {object:node} "first.async.com" is committed
+      And after 1 second
     Then {object:node} "first.async.com" should be in state "transition"
-      And {object:node} "first.async.com" should not be in state "ready"
+      And {object:node} "first.async.com" should not be in state "active"
       And {object:node} "first.async.com" should not be in state "todo"
-    Finally I remove the {object:node} "first.async.com"
+    Finally REST removes the {object:node} "first.async.com"
 
   Scenario: Async past transition
     Given REST creates the {object:node} "second.async.com"
-    When {object:node} "first.async.com" has the "test-async" role
-      And I sleep for 1 second
-    Then {object:node} "first.async.com" should be in state "transition"
-      And {object:node} "first.async.com" should not be in state "ready"
-      And {object:node} "first.async.com" should not be in state "todo"
-    Finally I remove the {object:node} "first.async.com"
+      And {object:node} "second.async.com" has the "test-async" role
+      And {object:node} "second.async.com" is committed
+      And after 1 second
+    When REST retries {object:node} "second.async.com" {object:node_role} "test-async"
+      And after 1 second
+    Then {object:node} "second.async.com" should not be in state "transition"
+      And {object:node} "second.async.com" should be in state "active"
+      And {object:node} "second.async.com" should not be in state "todo"
+    Finally REST removes the {object:node} "second.async.com"

--- a/BDD/features/async.feature
+++ b/BDD/features/async.feature
@@ -1,0 +1,30 @@
+Feature: Async
+  In order to allow external operations
+  The system operator, Oscar
+  wants to be able to allow node roles to spin while he works
+
+  Scenario: Node goes to ready in 1 second
+    Given REST creates the {object:node} "base.async.com"
+    When I sleep for 1 second
+    Then {object:node} "base.async.com" should not be in state "transition"
+      And {object:node} "base.async.com" should not be in state "todo"
+      And {object:node} "base.async.com" should be in state "ready"
+    Finally I remove the {object:node} "base.async.com"
+
+  Scenario: Async holds in transition
+    Given REST creates the {object:node} "first.async.com"
+    When {object:node} "first.async.com" has the "test-async" role
+      And I sleep for 1 second
+    Then {object:node} "first.async.com" should be in state "transition"
+      And {object:node} "first.async.com" should not be in state "ready"
+      And {object:node} "first.async.com" should not be in state "todo"
+    Finally I remove the {object:node} "first.async.com"
+
+  Scenario: Async past transition
+    Given REST creates the {object:node} "second.async.com"
+    When {object:node} "first.async.com" has the "test-async" role
+      And I sleep for 1 second
+    Then {object:node} "first.async.com" should be in state "transition"
+      And {object:node} "first.async.com" should not be in state "ready"
+      And {object:node} "first.async.com" should not be in state "todo"
+    Finally I remove the {object:node} "first.async.com"

--- a/barclamps/test.yml
+++ b/barclamps/test.yml
@@ -24,6 +24,14 @@ roles:
         map: 'test/delay'
         description: 'UI Simulated Delay'
         ui_renderer: 'barclamp_test/attribs/delay'
+  - name: test-async
+    jig: role-provided
+    attribs:
+      - name: async-result 
+        map: 'async/result'
+        schema:
+          type: str
+          required: false
   - name: test-server
     jig: test
     requires:

--- a/barclamps/test.yml
+++ b/barclamps/test.yml
@@ -26,6 +26,8 @@ roles:
         ui_renderer: 'barclamp_test/attribs/delay'
   - name: test-async
     jig: role-provided
+    requires:
+      - test-client
     attribs:
       - name: async-result 
         map: 'async/result'

--- a/bin/crowbar
+++ b/bin/crowbar
@@ -486,6 +486,13 @@ class ProxyWithAttribs < CrowbarProxy
     self
   end
 
+  def do_retry(*rest)
+    obj,res = REST.put("#{self.class.path}/#{id}/retry")
+    maybe_json_die(obj,res)
+    @blob = obj
+    self
+  end
+
 end
 
 module OpenCrowbar

--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -31,8 +31,14 @@ class NodesController < ApplicationController
     end
   end
   
+  # API /api/status/nodes(/:id)
   def status
-    nodes = Node.all
+    nodes = if params[:id]
+      node = Node.find_key params[:id]
+      nodes = Node.where :id=>node.id
+    else
+      nodes = Node.all
+    end
     status = {}
     nodes.each do |n|
       state = n.state

--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -95,7 +95,7 @@ class Barclamp < ActiveRecord::Base
         jig_active = if (Rails.env == "production")
                        jig_name != "test"
                      else
-                       ["noop","test"].include? jig_name
+                       ["noop","test","role-provided"].include? jig_name
                      end
         jig = jig_type.constantize.find_or_create_by!(:name => jig_name)
         jig.update_attributes!(:order => 100,

--- a/rails/app/models/barclamp_test/async.rb
+++ b/rails/app/models/barclamp_test/async.rb
@@ -26,6 +26,7 @@ class BarclampTest::Async < Role
     if File.exists? file_name
       # read the file
       ticket = JSON::load File.open(file_name, 'r')
+      File.delete file_name
       # set the attributes
       runlog << "Setting #{service_name} attribute"
       Attrib.set('async-result', nr, ticket, :system)

--- a/rails/app/models/barclamp_test/async.rb
+++ b/rails/app/models/barclamp_test/async.rb
@@ -45,7 +45,7 @@ class BarclampTest::Async < Role
     File.open(file_name,"w") { |f| f.write("{\"async\":{\"result\":#{nr.id}}}") }
     Rails.logger.info("Started waiting for #{service_name}.  Created file #{file_name}")
       # put data into the run log
-    runlog << "Processing pieces for #{service_name}"
+    runlog << "Retry the NodeRole to complete processing for #{service_name}"
     nr.runlog = runlog.join("\n")
     nr.save!
     # this will allow run to complete but role stays in execute

--- a/rails/app/models/barclamp_test/async.rb
+++ b/rails/app/models/barclamp_test/async.rb
@@ -1,0 +1,55 @@
+# Copyright 2015, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.  
+
+class BarclampTest::Async < Role
+
+  def do_transition(nr, data)
+
+    runlog = []
+    service_name = 'async-result'
+    file_name = File.join 'tmp', "async_#{nr.id}.txt"
+    
+    runlog << "Processing pieces for #{service_name}"
+
+    # CASE CLOSE - normal close
+    if File.exists? file_name
+      # read the file
+      ticket = JSON::load File.open(file_name, 'r')
+      # set the attributes
+      runlog << "Setting #{service_name} attribute"
+      Attrib.set('async-result', nr, ticket, :system)
+      raise "#{service_name} not available" if false  # test to make sure we're ok
+      # put data into the run log
+      runlog << "Finished processing pieces for #{service_name}"
+      nr.runlog = runlog.join("\n")
+      nr.save!
+      # finish up
+      Rails.logger.info("Finished waiting for #{service_name}")
+      return nil      
+    end
+
+    # CASE ASYNC - keep running
+    # create the file
+    File.open(file_name,"w") { |f| f.write("{\"async\":{\"result\":#{nr.id}}}") }
+    Rails.logger.info("Started waiting for #{service_name}.  Created file #{file_name}")
+      # put data into the run log
+    runlog << "Processing pieces for #{service_name}"
+    nr.runlog = runlog.join("\n")
+    nr.save!
+    # this will allow run to complete but role stays in execute
+    return :async
+
+  end
+
+end

--- a/rails/app/models/node.rb
+++ b/rails/app/models/node.rb
@@ -101,7 +101,9 @@ class Node < ActiveRecord::Base
           return NodeRole::PROPOSED
         elsif nr.error?
           return NodeRole::ERROR
-        elsif [NodeRole::BLOCKED, NodeRole::TODO, NodeRole::TRANSITION].include? nr.state
+        elsif nr.transition?
+          return NodeRole::TRANSITION
+        elsif [NodeRole::BLOCKED, NodeRole::TODO].include? nr.state
           return NodeRole::TODO
         end
       end


### PR DESCRIPTION
To enable a simulator for UI development, we need  way to have workflows that can be externally governed.  This same need also helps with external actions like creating a help ticket in an external system or when humans need to take actions.

These minor changes allow for roles to control asynchronous actions.  I will have a future pull request that shows how this works with the test role and includes some BDD tests for it.

The very simple explanation is that roles are allowed to return :async symbol and leave the runner WITHOUT changing the state from transition to active.  To complete the operation, the external entity needs to RETRY the role and then have the role return normally.