### PR TITLE
Bug #400 fix annoying popup digest auth on login

### DIFF
--- a/rails/app/views/layouts/application.html.haml
+++ b/rails/app/views/layouts/application.html.haml
@@ -81,4 +81,5 @@
     });
   }
 
-  heartbeat();
+  - if current_user or session[:digest_user]
+    heartbeat();


### PR DESCRIPTION
this was caused by the polling on the application template page.  I added a condition that would keep the poll from starting if you are not logged in.