### PR TITLE
bug #399 do not add chef roles if chef not active (unbreak BDD dev:pop)

### DIFF
--- a/rails/app/models/barclamp_chef/client.rb
+++ b/rails/app/models/barclamp_chef/client.rb
@@ -1,10 +1,18 @@
 class BarclampChef::Client < Role
+
+  # create the right private key for chef-client and registers it with the server
   def on_todo(nr)
     # Create chef metadata if needed.
     d = (nr.sysdata["chefjig"]["client"]["key"] rescue nil)
     return if d
     chefjig = Jig.where(:name => "chef").first
     raise "Cannot load Chef Jig" unless chefjig
+    # we have a problem is if the chef jig is not active
+    unless chefjig.active  
+      Rails.logger.warn "Unexpected: Chef Jig should have been active for Chef Client Role to initialize" unless Rails.env.development?
+      return
+    end
+    # creating the node in chef server
     chef_node, chef_role, chef_client = chefjig.create_node(nr.node)
     private_key = nil
     # Sometimes we get an APICilent back, sometimes we get a hash.


### PR DESCRIPTION
the chef client role was adding roles outside of the normal graph resolver.  That's OK, but it was breaking the development mode simulator.  

I added some logic that will skip this step if the chef jig is not active.  If we're in development then it's silent, otherwise, it will log a warning.