### PR TITLE
Deployment shows services on page

### DIFF
--- a/BDD/crowbar.erl
+++ b/BDD/crowbar.erl
@@ -161,9 +161,12 @@ step(_Global, {step_setup, {_Scenario, _N}, Test}) ->
   O = bdd_restrat:get_object(R),
   bdd_utils:log(debug, crowbar, global_setup, "Checking for Phantom Node Roles ~p",[O#list.count]),
   case O#list.count of
-    1 -> [node:bind(Phantom,PR) || PR <- PhantomRoles],
-            node:commit(Phantom),
-            node:alive(Phantom);
+    1 -> Attribs = ["chef-server_port", "chef-server_protocol"],
+          JSON = [crowbar:json([{name, A}, {description, g(description)}, {barclamp, 'test'}, {order, g(order)}, {writable, true}]) || A <- Attribs],
+          [bdd_restrat:create(attrib:g(path), J, attrib, 0) || J <- JSON],
+          [node:bind(Phantom,PR) || PR <- PhantomRoles],
+          node:commit(Phantom),
+          node:alive(Phantom);
     _  -> noop 
   end,
   true;

--- a/BDD/dev.erl
+++ b/BDD/dev.erl
@@ -66,7 +66,8 @@ pop(ConfigRaw)  ->
 % tear it down
 unpop()       ->  
   {ok, Build} = file:consult(bdd_utils:config(simulator, "dev.config")),
-  [ remove(N) || {N, _, _, _, _} <- buildlist(Build, nodes) ], 
+  [ remove(N2) || {N2, _, _} <- buildlist(Build, deployments) ], 
+  [ remove(N1) || {N1, _, _, _, _} <- buildlist(Build, nodes) ], 
   bdd_crud:delete(node:g(path), g(node_name)),
   bdd:stop([]). 
 
@@ -75,7 +76,8 @@ buildlist(Source, Type) ->
   R.
 
 remove(Atom) ->
-  bdd_crud:delete(Atom).
+  [{http, Msg, _Code, _URL, _, _, crowbar, _}] = bdd_crud:delete(Atom),
+  bdd_utils:log(info, dev, remove, "Removed ~p with status ~p", [Atom, Msg]).
 
 add_node({Atom, Name, Description, Order, Group}) ->
   Path = bdd_restrat:alias(node, g, [path]),

--- a/doc/development-guides/testing/bdd/internals/config.md
+++ b/doc/development-guides/testing/bdd/internals/config.md
@@ -95,7 +95,18 @@ BDD selects the `default.config` file automatically.  You can choose which confi
     <td>--url</td>
     <td>Used by bdd_clirat to pass the URL into the CLI</td>
   </tr>
-  
+  <tr>
+    <td>system_phantom</td>
+    <td>no</td>
+    <td>system-phantom.internal.local</td>
+    <td>Used by Crowbar to set the name of the phantom</td>
+  </tr>
+  <tr>
+    <td>system_phantom_roles</td>
+    <td>no</td>
+    <td>["dns-service", "ntp-service","dns-mgmt_service"]</td>
+    <td>Used by Crowbar to set the name of the phantom roles</td>
+  </tr>
 </table>
 
 

--- a/rails/app/controllers/deployments_controller.rb
+++ b/rails/app/controllers/deployments_controller.rb
@@ -30,8 +30,9 @@ class DeploymentsController < ApplicationController
         @roles = @deployment.deployment_roles.sort{|a,b|a.role.cohort <=> b.role.cohort}
         # alpha lists by ID
         @nodes = Node.order("name ASC").select do |n|
+          (!n.is_system? and
           (n.deployment_id == @deployment.id) ||
-          (n.node_roles.where(:deployment_id => @deployment.id).count > 0)
+          (n.node_roles.where(:deployment_id => @deployment.id).count > 0))
         end
       }
       format.json { render api_show @deployment }

--- a/rails/app/models/deployment.rb
+++ b/rails/app/models/deployment.rb
@@ -56,6 +56,10 @@ class Deployment < ActiveRecord::Base
     read_attribute("system")
   end
 
+  def system_node
+    nodes.where(:system => true).first
+  end
+
   def available_roles
     Role.active - roles
   end
@@ -134,6 +138,7 @@ class Deployment < ActiveRecord::Base
                    admin: false,
                    system: true,
                    alive: true,
+                   deployment_id: self.id,
                    bootenv: "local")
     rescue Exception => e
       puts "failed to add node: #{e.message}"

--- a/rails/app/views/deployments/show.html.haml
+++ b/rails/app/views/deployments/show.html.haml
@@ -1,5 +1,18 @@
 - state = @deployment.state rescue Deployment::ERROR
-%table{:width=>'100%'}
+
+- if @deployment.system_node
+  %table.services{:align=>'right'}
+    %tr
+      %td{:colspan=>2, :align=>'right'}= t '.services'
+    - @deployment.system_node.node_roles.each do |srv_role|
+      %tr
+        %td{:align=>'right'}
+          = link_to srv_role.role.name.html_safe, node_role_path(srv_role.id)
+        %td
+          %span{:align=>'center'}
+            .led{:style=>"margin:0px auto; text-align:left", :class => NodeRole::STATES[srv_role.state || NodeRole::ERROR], :title=>srv_role.role.name}
+
+%table
   %tr
     %td
       .led{:class => Deployment::STATES[state], :title=>Deployment.state_name(state)}

--- a/rails/app/views/nodes/show.html.haml
+++ b/rails/app/views/nodes/show.html.haml
@@ -16,7 +16,8 @@
     %td
       %h1
         = @node.alias || @node.name
-        = t '.admin' if @node.admin
+        = t '.admin' if @node.is_admin?
+        = t '.system' if @node.is_system?
 
 = render :partial => 'show', :locals => { :node => @node }
 

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -274,6 +274,7 @@ en:
     show:
       graph: "Graph"
       assign: "Assign Nodes to Roles"
+      services: Deployment Services
       assigned: "Assigned Nodes to Roles"
       roles: "Assigned Roles"
       available_nodes: "Available Nodes"
@@ -352,7 +353,8 @@ en:
       available: "Available"
       addresses: "Addresses"
       all_node_roles: "All Node Roles"
-      admin: "(admin)"
+      admin: "(Admin)"
+      system: "(System)"
       attribs: "Attributes"
       name: "Name"
       description: "Description"


### PR DESCRIPTION
This pull has a few items:
1) cleanup the deployment to create phantom nodes with a deployment
2) show services in a different place than regular nodes (cleans up phantoms on main deployment)
3) show service flag for service nodes
4) fix BDD so it can create/handle service nodes

Related to #394 (needs #411 )