### PR TITLE
fix #414 by making network role not hard coded.  

### DIFF
--- a/rails/app/views/dashboard/getready.html.haml
+++ b/rails/app/views/dashboard/getready.html.haml
@@ -41,7 +41,7 @@
         %th= t('.proc')
         %th= t('.asset')
     %tbody
-      - if @nodes and @nodes.count > 1
+      - if @nodes and @nodes.count > 0
         - @nodes.sort_by{|n| n.name }.each do |node|
           - unless node.is_admin? or node.is_system?
             %tr.node{ :class => cycle(:odd, :even, :name => "nodes"), :id => node.id }


### PR DESCRIPTION
The primary fix here was to not hardcode 'network-pilot' when we add it to the new deployment.

To make more readable, I refactored naming a little.

Also I fixed UI rendering because of phantom nodes were throwing off the count 'no_items' message when there was nothing to do.