### PR TITLE
Put centos6.5 back as a provisionable OS.  Admin node needs

### DIFF
--- a/chef/roles/provisioner-base-images/role-template.json
+++ b/chef/roles/provisioner-base-images/role-template.json
@@ -26,6 +26,13 @@
                         "iso_file": "RHEL6.5-20131111.0-Server-x86_64-DVD1.iso",
                         "append": "method=%os_install_site%"
                     },
+                    "centos-6.5": {
+                        "initrd": "images/pxeboot/initrd.img",
+                        "kernel": "images/pxeboot/vmlinuz",
+                        "append": "method=%os_install_site%",
+                        "iso_file": "CentOS-6.5-x86_64-bin-DVD1.iso",
+                        "online_mirror": "http://mirrors.kernel.org/centos/6/"
+                    },
                     "centos-6.6": {
                         "initrd": "images/pxeboot/initrd.img",
                         "kernel": "images/pxeboot/vmlinuz",


### PR DESCRIPTION
6.6, but it is useful to install 6.5 as well.

Fixes bug #418