### PR TITLE
Allow kvm-admin to autoinstall

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,14 @@ if [[ $http_proxy && !$no_proxy ]] ; then
     export no_proxy="127.0.0.1,localhost,::1"
 fi
 
+hostname_re='([[:alnum:]]+\.){2,}[[:alnum:]]+'
+
+check_hostname() {
+    [[ $(hostname) =~ $hostname_re ]] && return
+    echo "The hostname for the system must already be set to its proper name!"
+    exit 1
+}
+
 prefix_r=(recipe[barclamp]
           recipe[ohai]
           recipe[utils])

--- a/chef/cookbooks/crowbar-bootstrap/recipes/boot.rb
+++ b/chef/cookbooks/crowbar-bootstrap/recipes/boot.rb
@@ -372,6 +372,11 @@ directory "/home/crowbar/.ssh" do
   mode 0755
 end
 
+bash "Fix up /opt/opencrowbar permissions" do
+  code 'cd /opt/opencrowbar; chown -R crowbar:crowbar .'
+  not_if "su -c 'test -w /opt/opencrowbar/core' crowbar"
+end
+
 bash "Regenerate Crowbar SSH keys" do
   code "su -l -c 'ssh-keygen -q -b 2048 -P \"\" -f /home/crowbar/.ssh/id_rsa' crowbar"
   not_if "test -f /home/crowbar/.ssh/id_rsa"

--- a/chef/cookbooks/crowbar-bootstrap/recipes/goiardi.rb
+++ b/chef/cookbooks/crowbar-bootstrap/recipes/goiardi.rb
@@ -30,6 +30,7 @@ template "/etc/goiardi/goiardi.conf" do
             protocol: goiardi_protocol,
             conf_root: "/etc/goiardi",
             use_auth: true,
+            hostname: node[:machinename],
             local_filestore: "/var/cache/goiardi",
             index_file: "/var/cache/goiardi/index.bin"
 end

--- a/chef/cookbooks/crowbar-bootstrap/templates/default/goiardi.conf.erb
+++ b/chef/cookbooks/crowbar-bootstrap/templates/default/goiardi.conf.erb
@@ -4,6 +4,7 @@ conf-root = "<%= @conf_root %>"
 use-auth = <%= @use_auth %>
 db-pool-size = 5
 max-connections = 50
+hostname = "<%= @hostname %>"
 <% if @protocol == "https" -%>
 use-ssl = true
 ssl-cert = "https-cert.pem"

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -196,4 +196,11 @@ end
   end
   a.run_action(:remove)
 end
+
+
+bash "Restore selinux contexts for #{tftproot}" do
+  code "restorecon -R -F #{tftproot}"
+  only_if "which selinuxenabled && selinxenabled"
+end
+
 node.normal["crowbar_wall"]["dhcp"]["clients"]=new_clients

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -18,37 +18,14 @@ date
 
 . /etc/profile
 cd /opt/opencrowbar/core
+. ./bootstrap.sh
 
-[[ $1 ]] || {
-    echo "Must pass the FQDN you want the admin node to have as the first argument!"
-    exit 1
-}
+check_hostname
 
-FQDN=$1
+[[ $FQDN ]] || export FQDN="$(hostname)"
 
 DOMAINNAME=${FQDN#*.}
-if [[ ! -f /.dockerenv ]]; then
-    HOSTNAME=${FQDN%%.*}
-    # Fix up the localhost address mapping.
-    sed -i -e "s/\(127\.0\.0\.1.*\)/127.0.0.1 $FQDN $HOSTNAME localhost.localdomain localhost/" /etc/hosts
-    sed -i -e "s/\(127\.0\.1\.1.*\)/127.0.1.1 $FQDN $HOSTNAME localhost.localdomain localhost/" /etc/hosts
-    # Fix Ubuntu/Debian Hostname
-    echo "$FQDN" > /etc/hostname
-    hostname $FQDN
-else
-    HOSTNAME=$(cat /etc/hostname)
-    FQDN="${HOSTNAME}.${DOMAINNAME}"
-fi
-
-export FQDN
-
-# Fix CentOs/RedHat Hostname
-if [ -f /etc/sysconfig/network ] ; then
-  sed -i -e "s/HOSTNAME=.*/HOSTNAME=$FQDN/" /etc/sysconfig/network
-fi
-
-# Set domainname (for dns)
-echo "$DOMAINNAME" > /etc/domainname
+HOSTNAME=${FQDN%%.*}
 
 if [[ $http_proxy && !$upstream_proxy ]] && ! pidof squid; then
     export upstream_proxy=$http_proxy

--- a/crowbar-consul.sh
+++ b/crowbar-consul.sh
@@ -21,6 +21,8 @@ date
 
 which consul && consul watch -service=consul -type=service  | grep -q Node && exit 0
 
-# install the database
+check_hostname
+
+# install Consul
 chef-solo -c /opt/opencrowbar/core/bootstrap/chef-solo.rb -o "${consul_recipes}"
 

--- a/crowbar-core.sh
+++ b/crowbar-core.sh
@@ -19,8 +19,8 @@ date
 # setup & load env info
 if [[ ! -f /etc/profile.d/crowbar.sh ]]; then
     cat > /etc/profile.d/crowbar.sh <<EOF
-if ! fgrep -q '/opt/opencrowbar/core/bin' < <(echo $PATH); then
-    export PATH=$PATH:/opt/opencrowbar/core/bin
+if ! fgrep -q '/opt/opencrowbar/core/bin' < <(echo \$PATH); then
+    export PATH=\$PATH:/opt/opencrowbar/core/bin
 fi
 EOF
 fi

--- a/crowbar-core.sh
+++ b/crowbar-core.sh
@@ -27,8 +27,11 @@ fi
 . ./bootstrap.sh
 
 if [[ ! $RAILS_ENV ]]; then
-	export RAILS_ENV=$1
+    echo "RAILS_ENV not set!"
+    exit 1
 fi
+
+check_hostname
 
 . /etc/profile
 ./setup/00-crowbar-rake-tasks.install && \

--- a/crowbar-database.sh
+++ b/crowbar-database.sh
@@ -21,6 +21,8 @@ date
 
 which consul && consul watch -service=crowbar-database -type=service  | grep -q Node && exit 0
 
+check_hostname
+
 # install the database
 chef-solo -c /opt/opencrowbar/core/bootstrap/chef-solo.rb -o "${database_recipes}"
 

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -608,6 +608,9 @@ rpms:
     - tcpdump
     - vim
     - zlib-devel
+    - mercurial
+    - screen
+    - policycoreutils-python
     # postgresql 93 stuff
     - postgresql93
     - postgresql93-devel

--- a/production.sh
+++ b/production.sh
@@ -15,10 +15,6 @@
 
 date
 export RAILS_ENV=production
-[[ $1 ]] || {
-    echo "Must pass the FQDN you want the admin node to have as the first argument!"
-    exit 1
-}
 
 cd /opt/opencrowbar/core
 . ./bootstrap.sh
@@ -26,8 +22,46 @@ set -e
 if [[ $http_proxy && !$upstream_proxy ]] && ! pidof squid; then
     export upstream_proxy=$http_proxy
 fi
+
+hostname_re='([[:alnum:]]+\.){2,}[[:alnum:]]+'
+FQDN=$(hostname)
+if [[ $1 ]]; then
+    if [[ $1 != $FQDN ]]; then
+        if ! [[ $1 =~ $hostname_re ]]; then
+            echo "Cannot set system hostname to $1, it is not a valid hostname!"
+            exit 1
+        fi
+        if [[ -f /.dockerenv ]]; then
+            FQDN="$(hostname -s).${1#*.}"
+        else
+            FQDN="$1"
+            # Fix up the localhost address mapping.
+            sed -i -e "s/\(127\.0\.0\.1.*\)/127.0.0.1 $FQDN $HOSTNAME localhost.localdomain localhost/" /etc/hosts
+            sed -i -e "s/\(127\.0\.1\.1.*\)/127.0.1.1 $FQDN $HOSTNAME localhost.localdomain localhost/" /etc/hosts
+            # Fix Ubuntu/Debian Hostname
+            echo "$FQDN" > /etc/hostname
+        fi
+        echo "Changing system hostname from $(hostname) to $FQDN"
+        hostname $FQDN
+    fi
+elif ! [[ $FQDN =~ $hostname_re ]]; then
+    echo "$FQDN is not a valid FQDN"
+    echo "Please pass one as the first parameter to this script so we can set it."
+    exit 1
+fi
+ 
+# Fix CentOs/RedHat Hostname
+if [ -f /etc/sysconfig/network ] ; then
+  sed -i -e "s/HOSTNAME=.*/HOSTNAME=$FQDN/" /etc/sysconfig/network
+fi
+
+# Set domainname (for dns)
+echo "${FQDN#*.}" > /etc/domainname
+
+export FQDN
+
 ./crowbar-boot.sh
 ./crowbar-consul.sh
 ./crowbar-database.sh
-./crowbar-core.sh "$RAILS_ENV"
-./crowbar-config.sh "$@"
+./crowbar-core.sh
+./crowbar-config.sh

--- a/tools/kvm-admin
+++ b/tools/kvm-admin
@@ -80,7 +80,7 @@ myclean() {
     if [[ $save_image = true ]]; then
         kill_vm killed
         echo "Saving the disk image to $image_name.  Please do not interrupt!"
-        qemu-img convert -c -p -f raw -O qcow2 "$VM_DIR/$VMID.disk" "$image_name"
+        qemu-img convert -c -p -f qcow2 -O qcow2 "$VM_DIR/$VMID.disk" "$image_name"
     fi
     cleanup
     kill_ocb_bridge
@@ -262,7 +262,7 @@ fi
 
 make_ocb_bridge
 if [[ ! $use_image = true ]]; then
-    qemu-img create -f raw "$VM_DIR/$VMID.disk" 30G &>/dev/null
+    qemu-img create -f qcow2 "$VM_DIR/$VMID.disk" 30G &>/dev/null
 fi
 makenics
 # Let the admin node talk to the outside world.
@@ -270,14 +270,15 @@ sudo iptables -t nat -A POSTROUTING -s 192.168.124.0/24 \! -d 192.168.124.0/24 -
 
 if [[ ! $use_image = true ]]; then
     # Kick off the installer
-    run_kvm -kernel "$admin_server_loc/install/images/pxeboot/vmlinuz" \
+    run_kvm -diskformat qcow2 \
+            -kernel "$admin_server_loc/install/images/pxeboot/vmlinuz" \
             -initrd "$TMPDIR/initrd.img" \
             -append "${install_params[*]}" \
-            -cdrom "$admin_server_iso"
+            -cdrom "$admin_server_iso" 
 fi
 
 # Once we get here, the OS should be installed.
-admin_args=(-bootc)
+admin_args=(-bootc -diskformat qcow2)
 if [[ $use_image = true ]]; then
     admin_args+=(-disk "$image_name")
 fi
@@ -292,6 +293,7 @@ while [[ ! -f $VM_DIR/$VMID.killed ]]; do
         done
         ssh -f root@192.168.124.10 -- screen -d -m -S ocb-install -t 'Shell'
         ssh -f root@192.168.124.10 -- "screen -X caption always '%{-b ..}%-w%{+b ..}[[%n%f*%t]]%{-}%+w'"
+        ssh -f root@192.168.124.10 -- screen -S ocb-install -X zombie kr
         if [[ $autoinstall = true ]]; then
             ssh root@192.168.124.10 -- screen -S ocb-install -X \
                 screen -t 'Install' "/opt/opencrowbar/core/production.sh $ADMIN_HOSTNAME"

--- a/tools/kvm-admin
+++ b/tools/kvm-admin
@@ -7,11 +7,14 @@ set -e
 if [[ $0 = /* ]]; then
     OCBDIR="$0"
 elif [[ $0 = .*  || $0 = */* ]]; then
-    OCBDIR="$(readlink -f "$PWD/$0")"
+    OCBDIR="$PWD/$0"
 else
     echo "Cannot figure out where we are!"
     exit 1
 fi
+
+OCBDIR="$(readlink -f "$OCBDIR")"
+export OCBDIR="${OCBDIR%/core/tools/kvm-admin}"
 
 while [[ $1 ]]; do
     case $1 in
@@ -46,17 +49,24 @@ while [[ $1 ]]; do
             fi
             ephemeral_admin=true
             shift 2;;
+        --develop) no_rpms=true; shift;;
+        --autoinstall)
+            autoinstall=true
+            no_rpms=true
+            hostname="$ADMIN_HOSTNANE"
+            shift;;
         *)
             echo "Invalid options: ${*}"
             echo "Please try one of:"
             echo "   --save-image <file> to save the admin disk image after kvm-admin is killed,"
             echo "   --demo <file> to run a previosly-saved image discarding changes,"
             echo "   --use-image <file> to run a previously-saved image keeping changes"
+            echo "   --develop to use the current code directly instead of creating RPMS"
+            echo "   --autoinstall to automatically start installing the admin node."
+            echo "                 Implies --develop"
             exit 1;;
     esac
 done
-
-export OCBDIR="${OCBDIR%/core/tools/kvm-admin}"
 
 admin_server_loc="$HOME/.cache/opencrowbar/tftpboot/centos-6.6"
 admin_server_iso="$HOME/.cache/opencrowbar/tftpboot/isos/CentOS-6.6-x86_64-bin-DVD1.iso"
@@ -81,12 +91,14 @@ if [[ ! $use_image = true ]]; then
         echo "Cannot find $admin_server_iso"
         exit 1
     fi
-    if [[ ! -d $OCBDIR/build-tools/.git ]]; then
-        echo "Cloning build-tools into $OCBDIR"
-        (cd "$OCBDIR" && git clone https://github.com/opencrowbar/build-tools)
+    if [[ ! $no_rpms ]]; then
+        if [[ ! -d $OCBDIR/build-tools/.git ]]; then
+            echo "Cloning build-tools into $OCBDIR"
+            (cd "$OCBDIR" && git clone https://github.com/opencrowbar/build-tools)
+        fi
+        echo "Creating OCB install RPM packages"
+        "$OCBDIR/build-tools/bin/make-rpms.sh"
     fi
-    echo "Creating OCB install RPM packages"
-    "$OCBDIR/build-tools/bin/make-rpms.sh"
 fi
 
 trap 'myclean' 0 INT QUIT TERM
@@ -94,7 +106,15 @@ trap 'myclean' 0 INT QUIT TERM
 if [[ ! $use_image = true ]]; then
     # Inject opencrowbar packages and kickstart into the PXE install ISO.
     mkdir -p "$TMPDIR/initrd"
-    tar -C "$admin_server_loc" -czf "$TMPDIR/initrd/ocb.tar.gz" ocb-packages
+    if [[ -d $HOME/.cache/opencrowbar/tftpboot/files ]]; then
+        tar -C "$HOME/.cache/opencrowbar/tftpboot" \
+            -czf "$TMPDIR/initrd/ocb-files.tar.gz" files
+    fi
+    if [[ $no_rpms ]]; then
+        tar -C "$OCBDIR" -czf "$TMPDIR/initrd/ocb.tar.gz" .
+    else
+        tar -C "$admin_server_loc" -czf "$TMPDIR/initrd/ocb.tar.gz" ocb-packages
+    fi
     cat >"$TMPDIR/initrd/opencrowbar.ks" <<'EOF'
 # Opencrowbar Admin Development Kickstart
 install
@@ -107,7 +127,6 @@ text
 rootpw --iscrypted $1$H6F/NLec$Fps2Ut0zY4MjJtsa1O2yk0
 firewall --disabled
 authconfig --enableshadow --enablemd5
-selinux --disabled
 timezone --utc UTC
 bootloader --location=mbr --driveorder=sda
 zerombr
@@ -131,6 +150,8 @@ emacs-nox
 openssh
 createrepo
 tcpdump
+screen
+policycoreutils-python
 
 %post --nochroot
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
@@ -141,6 +162,13 @@ tar -C /mnt/sysimage/opt/opencrowbar -xzf /ocb.tar.gz
 mkdir -p /mnt/sysimage/tftpboot/centos-6.6/install
 cp -a /mnt/source/. /mnt/sysimage/tftpboot/centos-6.6/install/.
 
+if [[ -f /ocb-files.tar.gz ]]; then
+    mkdir -p /mnt/sysimage/tftpboot
+    tar -C /mnt/sysimage/tftpboot -xzf /ocb-files.tar.gz
+    chown -R root:root /mnt/sysimage/tftpboot/files
+    chmod -R ugo+r /mnt/sysimage/tftpboot/files
+fi
+
 %post
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 exec > /root/post-install.log 2>&1
@@ -149,22 +177,56 @@ authkey_re='crowbar\.authkey=([^ ]+)'
 if [[ $(cat /proc/cmdline) =~ $authkey_re ]]; then
     mkdir -p "/root/.ssh"
     printf '%b\n'  "${BASH_REMATCH[1]}" >> "/root/.ssh/authorized_keys"
+    restorecon -Rv /root/.ssh
 fi
 mkdir -p /etc/profile.d
 for proxy in http_proxy https_proxy no_proxy; do
     match_re="crowbar\.$proxy=([^ ]+)"
     [[ $(cat /proc/cmdline) =~ $match_re ]] || continue
-    printf '%s="%b"\n' "$proxy" "${BASH_REMATCH[1]}" >> /etc/profile.d/10-proxies.sh
+    printf 'export %s="%b"\n' "$proxy" "${BASH_REMATCH[1]}" >> /etc/profile.d/proxy.sh
     printf '%s=%b\n' "$proxy" "${BASH_REMATCH[1]}" >> /etc/environment
 done
-[[ -f /etc/profile.d/10-proxies.sh ]] && chmod 755 /etc/profile.d/10-proxies.sh
 
-cat >/etc/yum.repos.d/local-ocb.repo <<EOR
+if [[ -d /opt/opencrowbar/ocb-packages ]]; then
+    cat >/etc/yum.repos.d/local-ocb.repo <<EOR
 [ocb]
 name=Local Opencrowbar
 baseurl=file:///opt/opencrowbar/ocb-packages
 gpgcheck=0
 EOR
+fi
+
+
+cat <<'EOQ' >/etc/ssh/sshd_config
+Port 22
+ListenAddress ::
+ListenAddress 0.0.0.0
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+UsePrivilegeSeparation yes
+KeyRegenerationInterval 3600
+ServerKeyBits 768
+SyslogFacility AUTH
+LogLevel INFO
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+RSAAuthentication yes
+PubkeyAuthentication yes
+IgnoreRhosts yes
+RhostsRSAAuthentication no
+HostbasedAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+TCPKeepAlive yes
+AcceptEnv LANG LC_*
+AcceptEnv http_proxy https_proxy no_proxy
+Subsystem sftp /usr/lib/openssh/sftp-server
+UsePAM no
+UseDNS no
+EOQ
 
 cat <<EOQ >/etc/sysconfig/network-scripts/ifcfg-eth0
 DEVICE=eth0
@@ -185,7 +247,6 @@ EOF
     cp "$admin_server_loc/install/images/pxeboot/initrd.img" "$TMPDIR"
     chmod 644 "$TMPDIR/initrd.img" 
     (cd "$TMPDIR/initrd"; find . -depth  |cpio --create --format=newc |gzip -9 >>"$TMPDIR/initrd.img")
-
     install_params=("ksdevice=eth0"
                     "ks=file:/opencrowbar.ks"
                     "ip=192.168.124.10"
@@ -225,7 +286,17 @@ if [[ $ephemeral_admin = true ]]; then
 fi
 while [[ ! -f $VM_DIR/$VMID.killed ]]; do
     update_vm_status "Booting node to disk"
-    if run_kvm "${admin_args[@]}"; then
+    if run_kvm "${admin_args[@]}" -daemonif "ping -q -c 1 -t 5 192.168.124.10"; then
+        while ! ssh root@192.168.124.10 true; do
+            sleep 5
+        done
+        ssh -f root@192.168.124.10 -- screen -d -m -S ocb-install -t 'Shell'
+        ssh -f root@192.168.124.10 -- "screen -X caption always '%{-b ..}%-w%{+b ..}[[%n%f*%t]]%{-}%+w'"
+        if [[ $autoinstall = true ]]; then
+            ssh root@192.168.124.10 -- screen -S ocb-install -X \
+                screen -t 'Install' "/opt/opencrowbar/core/production.sh $ADMIN_HOSTNAME"
+        fi
+        ssh -t root@192.168.124.10 -- screen -r -S ocb-install
         kill_vm exited
     else
         update_vm_status "Node failed to deploy."


### PR DESCRIPTION
Several changes here:

* Do the jiggery pokery needed to make the admin node run with selinux
  enabled.  This closes a few security holes.
* Have kvm-admin use the development trees directly instead of building
  RPMs.  This cuts down on the time and complication of building the
  RPMs locally.  Installation of the rpms is still possible by adding
  the appropriate yum repository and removing /opt/dell.
* Automatically create a screen session inside the admin node and SSH
  into the node as root once it is alive.
* Add the --autoinstall flag to kvm-admin.  This will have kvm-admin
  automatically kick off the autoinstall process with a randomly chosen
  hostname once it can ssh into the admin node.