### PR TITLE
IBM efi-hack to continue - still has bootorder issues.

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -76,7 +76,7 @@ if File.exists?("/sys/firmware/efi")
       end
     end
   end
-  unless bootargs.empty? || bootargs["Entries"].empty?
+  unless bootargs.empty? || bootargs["Entries"].empty? || bootargs["BootCurrent"].nil? || bootargs["Entries"][bootargs["BootCurrent"]].nil? || bootargs["Entries"][bootargs["BootCurrent"]].empty? || bootargs["Entries"][bootargs["BootCurrent"]]["Device"].nil?
     if bootargs["Entries"][bootargs["BootCurrent"]]["Device"] =~ /[\/)]MAC\(/i
       macaddr = bootargs["Entries"][bootargs["BootCurrent"]]["Device"].match(/[\/)]MAC\(([0-9a-f]+)/i)[1]
       bootargs["LastNetBootMac"] = ''


### PR DESCRIPTION
This is overkill, but handles a bad return from efibootmgr on IBM m-series systems.  It is not a complete solution but lets the system continue for continued debugging.