### PR TITLE
expose Role code URL on UI

### DIFF
--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -65,7 +65,7 @@ class Barclamp < ActiveRecord::Base
       version = bc["version"] || '2.0'
       build_version = bc["build_version"] || '2.0'
 
-      source_url = bc["source_url"] || "http://github/opencrowbar/unknown"
+      source_url = bc["source_url"]
       barclamp.update_attributes!(:description   => bc['description'] || bc_name.humanize,
                                   :version       => version,
                                   :build_version => build_version,

--- a/rails/app/models/role.rb
+++ b/rails/app/models/role.rb
@@ -141,6 +141,14 @@ class Role < ActiveRecord::Base
     name_i18n.gsub("-","&#8209;").gsub(" ","&nbsp;")
   end
 
+  def github
+    baseurl = barclamp.source_url
+    baseurl ||= barclamp.parent.source_url    
+    return I18n.t('unknown') unless baseurl
+    "#{baseurl}\/tree\/master\/#{jig.name}\/roles\/#{name}"
+
+  end
+
   def update_cohort
     Role.transaction do
       c = (parents.maximum("cohort") || -1)

--- a/rails/app/views/roles/show.html.haml
+++ b/rails/app/views/roles/show.html.haml
@@ -16,6 +16,9 @@
       - if Rails.env.development?
         %dt= t '.type'
         %dd= "[#{@role.class.to_s}]"
+      - if @role.github and (current_user.settings(:docs).sources rescue false)
+        %dt= t '.source'
+        %dd= link_to @role.github, @role.github
       %dt= t '.flags'
       %dd
         = t '.library' if @role.library 

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -465,6 +465,7 @@ en:
       attributes: "Defined Attributes"
       attrib: "Name"
       map: "Map"
+      source: "Source"
     names:
       role: "Roles"
     anneal:


### PR DESCRIPTION
A little UI play based on patterns & information that we already had in the system.  Basically, it builds a link to the code that the role will run (on master branch) in github.

This came up during a demo when someone asked to see the code the role was running.  This is handy and accurate enough to be useful for demos.