### PR TITLE
unpin scaffold workaround.

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -32,7 +32,7 @@ gem 'puma'
 #gem 'amqp'
 gem 'xml-simple'
 gem 'daemons'
-gem 'active_scaffold', git: 'https://github.com/activescaffold/active_scaffold', ref: '190145f4905a88'
+gem 'active_scaffold'
 gem 'devise', "~>3.0.0"
 gem 'rails_config'
 gem 'delayed_job'


### PR DESCRIPTION
this was an old fix - scaffolds is not used in the main UI at all.

this was causing issues for HTTPS lookups and is no longer needed.

connect to #425 