### PR TITLE
allow sledgehammer to cope with pre-created nodes

### DIFF
--- a/chef/cookbooks/provisioner/files/default/start-up.sh
+++ b/chef/cookbooks/provisioner/files/default/start-up.sh
@@ -2,23 +2,39 @@
 # Figure out where we PXE booted from.
 if ! [[ $(cat /proc/cmdline) =~ $host_re ]]; then
     export HOSTNAME="d${MAC//:/-}.${DOMAIN}"
-    # Create a new node for us,
-    # Add the default noderoles we will need, and
-    # Let the annealer do its thing.
-    curl -f -g --digest -u "$CROWBAR_KEY" -X POST \
-        -d "name=$HOSTNAME" \
-        -d "mac=$MAC" \
-        "$CROWBAR_WEB/api/v2/nodes/" && \
+    # does the node exist?
+    exists=$(curl -s -o /dev/null -w "%{http_code}" --digest -u "$CROWBAR_KEY" \
+    -X GET "$CROWBAR_WEB/api/v2/nodes/$HOSTNAME")
+    if [[ $exists == 404 ]]; then
+        # Create a new node for us,
+        # Add the default noderoles we will need, and
+        # Let the annealer do its thing.
+        curl -f -g --digest -u "$CROWBAR_KEY" -X POST \
+            -d "name=$HOSTNAME" \
+            -d "mac=$MAC" \
+            "$CROWBAR_WEB/api/v2/nodes/" || {
+            echo "We could not create a node for ourself!"
+            exit 1
+        }
+    else
+        echo "Node already created, moving on"
+    fi
+    # does the crowbar-managed-role exist?
+    managed=$(curl -s -o /dev/null -w "%{http_code}" --digest -u "$CROWBAR_KEY" \
+    -X GET "$CROWBAR_WEB/api/v2/nodes/$HOSTNAME/node_roles/crowbar-managed-node")
+    if [[ $managed == 404 ]]; then
         curl -f -g --digest -u "$CROWBAR_KEY" -X POST \
         -d "node=$HOSTNAME" \
         -d "role=crowbar-managed-node" \
         "$CROWBAR_WEB/api/v2/node_roles/" && \
         curl -f -g --digest -u "$CROWBAR_KEY" -X PUT \
         "$CROWBAR_WEB/api/v2/nodes/$HOSTNAME/commit" || {
-        echo "We could not create a node for ourself!"
-        exit 1
-    }
-
+        echo "We could not commit the node!"
+        exit 1 
+        }
+    else
+        echo "Node already committed, moving on"
+    fi
 else
     # Let Crowbar know that we are back, and booted into Sledgehammer.
     export HOSTNAME="${BASH_REMATCH[1]}"
@@ -26,6 +42,7 @@ else
         -X PUT "$CROWBAR_WEB/api/v2/nodes/$HOSTNAME" \
         -d 'alive=false' \
         -d 'bootenv=sledgehammer'
+    echo "Node is back.  Set not alive - will be set in control.sh!"
 fi
 
 # Figure out what IP addresses we should have.
@@ -102,6 +119,7 @@ chmod 755 /tmp/control.sh
 export CROWBAR_KEY PROVISIONER_WEB CROWBAR_WEB
 export MAC BOOTDEV DOMAIN HOSTNAME
 
+echo "transfer from start-up to control script"
 [[ -x /tmp/control.sh ]] && exec /tmp/control.sh
 
 echo "Did not get control.sh from $PROVISIONER_WEB/nodes/$HOSTNAME/control.sh"

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -24,7 +24,7 @@ check_hostname
 
 [[ $FQDN ]] || export FQDN="$(hostname)"
 
-DOMAINNAME=${FQDN#*.}
+export DOMAINNAME=${FQDN#*.}
 HOSTNAME=${FQDN%%.*}
 
 if [[ $http_proxy && !$upstream_proxy ]] && ! pidof squid; then

--- a/tools/kvm_lib.sh
+++ b/tools/kvm_lib.sh
@@ -164,6 +164,13 @@ makenics(){
         local nic_name="vm-$VMID-${idx}"
         maketap "$nic_name" "$OCB_BRIDGE"
         getmac
+        if [ $idx == 0 ]; then
+            local vm_name="d${MACADDR//:/-}"
+            echo == TO PRECREATE NODE, run these steps on the admin node:
+            echo   crowbar nodes create "\"{\\\"name\\\":\\\"$vm_name.\$DOMAINNAME\\\",\\\"mac\\\":\\\"$MACADDR\\\"}\""
+            echo   crowbar roles bind crowbar-managed-node to \"$vm_name.\$DOMAINNAME\"
+            echo   crowbar nodes commit \"$vm_name.\$DOMAINNAME\"
+        fi
         vm_nics+=("$MACADDR,$nic_name")
     done
 }


### PR DESCRIPTION
This pull is based on a desire to demo creating nodes BEFORE they are registered by sledgehammer.

First, I added some logic to print Crowbar CLI commands for the kvm-slave script that could be used to create the node on the admin instance.

Next, I had to modify sledgehammer start-up script to handle when the node that it is trying to create already exists.  The script was OK but did not handle the 500 (node exists) well.  To be more robust, I allowed the script to handle BOTH node is created with and without the noderole graph.

Finally, I tried to have the production script export the correct DOMAINNAME but that is not working correctly.  Right now you have to manually explore the DOMAINNAME.

Since this impacts the discovery & registration, PLEASE REVIEW AND TEST carefully.