### PR TITLE
Continue fixing issues with node destroy.  Remove chef info as well.

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -175,7 +175,7 @@ end
 # Now that we have handled any updates we care about, delete any info about nodes we have deleted.
 (node["crowbar_wall"]["dhcp"]["clients"].keys - new_clients.keys).each do |old_node_name|
   old_node = node["crowbar_wall"]["dhcp"]["clients"][old_node_name]
-  mac_list = old_node["mac_addresses"]
+  mac_list = old_node["mac_addresses"] || []
   mac_list.each_index do |idx|
     a = dhcp_host "#{old_node_name}-#{idx}" do
       hostname old_node_name
@@ -185,7 +185,7 @@ end
     end
     a.run_action(:remove)
   end
-  a = provisioner_bootfile old_node["bootenv"] do
+  a = provisioner_bootfile old_node_name do
     action :nothing
     address mac_list
   end
@@ -194,7 +194,7 @@ end
     action :nothing
     recursive true
   end
-  a.run_action(:remove)
+  a.run_action(:delete)
 end
 
 

--- a/rails/app/models/barclamp_chef/client.rb
+++ b/rails/app/models/barclamp_chef/client.rb
@@ -34,4 +34,15 @@ class BarclampChef::Client < Role
       nr.save!
     end
   end
+
+  def on_node_delete(node)
+    chefjig = Jig.where(:name => "chef").first
+    raise "Cannot load Chef Jig" unless chefjig
+    # we have a problem is if the chef jig is not active
+    unless chefjig.active
+      Rails.logger.warn "Unexpected: Chef Jig should have been active for Chef Client Role to delete" unless Rails.env.development?
+      return
+    end
+    chefjig.delete_node(node)
+  end
 end


### PR DESCRIPTION
This addresses lingering delete issues in the provisioner and also hooks up removal of chef-server client and node resources.