### PR TITLE
protect from missing attribs on second pass.  workaround until root caus...

### DIFF
--- a/rails/app/models/attrib.rb
+++ b/rails/app/models/attrib.rb
@@ -82,7 +82,12 @@ class Attrib < ActiveRecord::Base
   end
 
   def self.get(name, from, source=:all)
-    (name.is_a?(Attrib) ? name : Attrib.find_key(name)).get(from, source)
+    begin
+      (name.is_a?(Attrib) ? name : Attrib.find_key(name)).get(from, source)       
+    rescue Exception => e
+      Rails.logger.warn "Warn, did not get #{name} from #{from.name} with error #{e.message}"
+      nil      
+    end
   end
 
   # Get the attribute value from the passed object.


### PR DESCRIPTION
added a protection for a case that only shows up if you run BDD two times.

Overall, this is a good protection to have and I added a useful log message so it's not a silent recovery.  Interestingly, this only causes issues in the API.  The UI returns fine.

I'm still looking at WHY the BDD cleanup causes some role-provided attribs to go away and will add tests to check against it in my next pull.

Until then, this will allow the current tests to pass if BDD is run twice (which only @ravolt ever does)