### PR TITLE
Async Tests Back On

### DIFF
--- a/BDD/bdd_catchall.erl
+++ b/BDD/bdd_catchall.erl
@@ -16,6 +16,11 @@
 -module(bdd_catchall).
 -export([step/2]).
 
+sleepy(Time, Multiplier, Units) ->
+  {T, _} = string:to_integer(Time),
+  bdd_utils:log(debug, bdd_catchall, step, "zzz...sleeping ~p ~p.", [T, Units]),
+  timer:sleep(T*Multiplier).
+
 step(_Global, {step_given, {Scenario, _N}, ["I mark the logs with",Mark]}) -> 
   URL = bdd_utils:config(marker_url, undefined),
   S = integer_to_list(Scenario),
@@ -29,23 +34,15 @@ step(_Global, {step_given, {Scenario, _N}, ["I mark the logs with",Mark]}) ->
   end;
 
 step(_Result, {_, _N, ["pause", Time, "seconds to", Message]}) -> 
-  {T, _} = string:to_integer(Time),
-  io:format("\t\t\t...paused ~p seconds in order to ~s.~n", [T, Message]),
-  timer:sleep(T*1000);
+  sleepy(Time, 1000, "seconds to "++Message);
 step(_Result, {_S, _N, ["after 1 second"]}) -> step(_Result, {_S, _N, ["after", "1", "seconds"]});
 step(_Result, {_, _N, ["after", Time, "seconds"]}) -> 
-  {T, _} = string:to_integer(Time),
-  io:format("\t\t\tzzz...sleeping ~p seconds.~n", [T]),
-  timer:sleep(T*1000);
+  sleepy(Time, 1000, "seconds");
 step(_Result, {_S, _N, ["after 1 minute"]}) -> step(_Result, {_S, _N, ["after", "1", "minutes"]});
 step(_Result, {_, _N, ["after", Time, "minutes"]}) -> 
-  {T, _} = string:to_integer(Time),
-  io:format("\t\t\tzzz...sleeping ~p minutes.~n", [T]),
-  timer:sleep(T*60000);
+  sleepy(Time, 60000, "minutes");
 step(_Result, {_, _N, ["after", Time, "milliseconds"]}) -> 
-  {T, _} = string:to_integer(Time),
-  io:format("\t\t\tzzz...sleeping ~p milliseconds.~n", [T]),
-  timer:sleep(string:to_integer(T));
+  sleepy(Time, 1, "milliseconds");
 
 step( _Global, {step_setup, _N, _}) -> 
   bdd_utils:log(info, bdd_catchall, step, "No Feature Setup Step.", []);

--- a/BDD/features/async.feature
+++ b/BDD/features/async.feature
@@ -3,8 +3,11 @@ Feature: Async
   The system operator, Oscar
   wants to be able to allow node roles to spin while he works
 
+  Scenario: Test-Async attrib is created
+    When REST gets the {object:attrib} "async-result"
+    Then the {object:attrib} is properly formatted
+
   Scenario: Node goes to ready in 1 second
-    Skip TODO @ZEHICLE figure out why not working
     Given REST creates the {object:node} "base.async.com"
     When after 1 second
     Then {object:node} "base.async.com" should not be in state "transition"
@@ -13,7 +16,6 @@ Feature: Async
     Finally REST removes the {object:node} "base.async.com"
 
   Scenario: Async holds in transition
-    Skip TODO @ZEHICLE figure out why not working
     Given REST creates the {object:node} "first.async.com"
       And {object:node} "first.async.com" has the "test-async" role
     When {object:node} "first.async.com" is committed
@@ -24,7 +26,6 @@ Feature: Async
     Finally REST removes the {object:node} "first.async.com"
 
   Scenario: Async past transition
-    Skip TODO @ZEHICLE figure out why not working
     Given REST creates the {object:node} "second.async.com"
       And {object:node} "second.async.com" has the "test-async" role
       And {object:node} "second.async.com" is committed

--- a/rails/app/models/barclamp_test/async.rb
+++ b/rails/app/models/barclamp_test/async.rb
@@ -19,6 +19,7 @@ class BarclampTest::Async < Role
     runlog = []
     service_name = 'async-result'
     file_name = File.join 'tmp', "async_#{nr.id}.txt"
+    Rails.logger.debug("Async Using File #{file_name} as detection token")
     
     runlog << "Processing pieces for #{service_name}"
 


### PR DESCRIPTION
This pull brings the Async feature tests back!!

There was a bug in the node.state routine (fixed in this pull) that was causing failures when the node-role graph was walked in different orders.

Also includes a minor refactoring of a BDD routine.

NOTE: There is still an issue when we run bdd twice against the same system due to invalid cleanup.  This was part of that investigation.