### PR TITLE
include layer cake in Feature 446

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
   - RAILS_ENV=test bundle exec rake db:seed
   - RAILS_ENV=test bundle exec rake test
   - RAILS_ENV=test bundle exec rspec
+  - sleep 10
 
 after_failure:
   - erl -s bdd failed travis -s init stop -noshell

--- a/rails/app/views/dashboard/_layercake.html.haml
+++ b/rails/app/views/dashboard/_layercake.html.haml
@@ -2,6 +2,16 @@
 %div.dots
   - @layers[layer].each do |nr|
     - unless nr.nil?
-      %span.led{:style=>"float:left", :class => NodeRole::STATES[nr.state || NodeRole::ERROR], 
+      - working = true
+      - node_led = 'on'
+      - if !nr.node.available
+        - node_led = (nr.node.alive ? 'reserved' : 'idle')
+        - working = false
+      - elsif !nr.node.alive
+        - node_led = 'off'
+        - working = false
+      - nr_led = NodeRole::STATES[nr.state || NodeRole::ERROR]
+      - nr_led = "wait" if !working and nr.state == NodeRole::TODO 
+      %span.led{:style=>"float:left", :class => nr_led, 
                   :title=>"#{nr.node.alias} #{nr.role.name}"}
         = link_to "&nbsp;&nbsp;&nbsp;&nbsp;".html_safe, node_role_path(nr.id)


### PR DESCRIPTION
as suggested by @galthaus the system view should also show the wait state
connect to #446 

Added sleep to travis to try and fix Coveralls timing issues.

NOTE: We may want a larger discussion about "wait" being a new state for node-roles.  I have resisted that in this series of pulls.