### PR TITLE
add bring system info to top of node page

### DIFF
--- a/rails/app/views/nodes/_show.html.haml
+++ b/rails/app/views/nodes/_show.html.haml
@@ -10,8 +10,7 @@
         - deployments = Deployment.all
         = f.collection_select :deployment_id, deployments, :id, :name, :selected=>@node.deployment.id
         %input.button{:type => "submit", :name => "update", :value => t('update'), }
-    %dt= t('.bootenv')
-    %dd= t(".#{@node.bootenv}", :default=>@node.bootenv)
+    = dl_item t('.bootenv'), t(".#{@node.bootenv}", :default=>@node.bootenv)
     %dt= t('.status')
     %dd
       = t (@node.alive ? ".alive" : ".dead")
@@ -22,19 +21,20 @@
 
 .column_50.last
   %dl
-    - switch = @node.attrib_switches.detect{ |k, v| v["link"] }.second  rescue nil # get the first active switch
-    - if switch and switch.length > 0
-      -if switch["unit"].eql? "-1"
-        = dl_item(t('.switch_name_port'), "#{switch["name"]} / #{switch["port"]}")
-      -else
-        = dl_item(t('.switch_name_unit_port'), "#{switch["name"]} / #{switch["unit"]} / #{switch["port"]}")
-    - else
-      = dl_item(t('.switch_name'), t('.switch_no_link'))
+    = dl_item(t('.vendor'), "#{@node.attrib_system_manufacturer} #{@node.attrib_system_product}")
+    = dl_item(t('.serial'), @node.attrib_system_serial_number)
+    = dl_item(t('.asset_tag'), @node.attrib_asset_tag)
     = dl_item(t('.hardware'), @node.attrib_hardware)
-    = dl_item(t('.cpu'), @node.attrib_cpu)
+    %dt= t('.cpu')
+    %dd
+      - raw =@node.attrib_cpu || t('unknown')
+      - if raw.start_with? "Intel(R)"
+        = image_tag("http://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/Intel-logo.svg/293px-Intel-logo.svg.png", height: 16, title:"Intel")
+        - raw = raw.gsub("Intel(R) ",'')
+      - raw = raw.gsub("CPU ", '')
+      = raw
     = dl_item(t('.memory'), format_memory(@node.attrib_memory))
     = dl_item(t('.number_of_drives'), "#{@node.attrib_number_of_drives || 0}, #{t('.raid')}: #{t('.'+(@node.attrib_raid_set || 'not_set'))}")
-    = dl_item(t('.asset_tag'), @node.attrib_asset_tag)
     - if Rails.env.development? and Jig.active('test')
       %dt= t '.bdd_marker'
       %dd= @node.attrib_bdd_marker || t('ignore')

--- a/rails/app/views/nodes/show.html.haml
+++ b/rails/app/views/nodes/show.html.haml
@@ -28,6 +28,17 @@
     = link_to t(".#{meth.to_s}"), "/api/v2/nodes/#{@node.id}/power?poweraction=#{meth.to_s}", :method=>:put, :class => 'button', :'data-remote' => true,:'data-confirm' => t('are_you_sure') 
 
 %h3= t '.addresses'
+
+%dl
+  - switch = @node.attrib_switches.detect{ |k, v| v["link"] }.second  rescue nil # get the first active switch
+  - if switch and switch.length > 0
+    -if switch["unit"].eql? "-1"
+      = dl_item(t('.switch_name_port'), "#{switch["name"]} / #{switch["port"]}")
+    -else
+      = dl_item(t('.switch_name_unit_port'), "#{switch["name"]} / #{switch["unit"]} / #{switch["port"]}")
+  - else
+    = dl_item(t('.switch_name'), t('.switch_no_link'))
+
 %table.data.box
   %thead
     %tr

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -353,7 +353,7 @@ en:
       node_roles: "In Process Actions"
       alive: "Alive"
       available: "Available"
-      addresses: "Addresses"
+      addresses: "Networking"
       all_node_roles: "All Node Roles"
       admin: "(Admin)"
       system: "(System)"
@@ -368,6 +368,8 @@ en:
       ip: IP Address
       status: Status
       state: State
+      vendor: "System Type"
+      serial: "Serial #"
       hardware: Hardware
       switch_name: "Switch Name"
       switch_port: "Switch Port"
@@ -389,7 +391,7 @@ en:
       release: "Release"
       bootenv: "Boot Environment"
       power: "Available Power Actions"
-      network: Network"
+      network: "Network"
       range: "Range"
       address: "Address"
       conduit: "Conduit"


### PR DESCRIPTION
move the vendor information to the top of the node page

had to move things around a little (switch moved to the network area)

Also, did some tweaks to make the CPU line shorter (replace Intel w/ logo, remove CPU)

connect to #444 