### PR TITLE
Last step for allowing custom Styles

### DIFF
--- a/doc/user-guide/README.md
+++ b/doc/user-guide/README.md
@@ -10,7 +10,8 @@ This is the (nascent) OpenCrowbar user guide.  Please feel free to add sections 
 | Error | ![Error (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/error.png) | Failed, Incomplete transition | 
 | Blocked | ![Blocked (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/blocked.png) | Annealer waiting until all prereq's met | 
 | Idle | ![Idle (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/active.png) | System not active | 
-| Off | ![Off (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/active.png) | Power is off.  No activity possible | 
+| Off | ![Off (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/off.png) | Power is off.  No activity possible | 
+| Wait | ![Wait (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/wait.png) | Todo action but power is off.  Waiting until power is on   | 
 | Proposed | ![Proposed (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/proposed.png) | Waiting on user input | 
 | Reserved | ![Reserved (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/reserved.png) | User hold on activity | 
 | To do | ![TODO (image)](https://raw.githubusercontent.com/opencrowbar/core/master/rails/public/images/icons/led/todo.png) | All prereq's met but not Annealer not started yet | 

--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -55,15 +55,16 @@ class Barclamp < ActiveRecord::Base
 
       Rails.logger.info "Importing Barclamp #{bc_name} from #{source_path}"
 
-      # verson tracking
-      gitcommit = "unknown"
-      gitdate = "unknown"
+      # verson tracking (use Git if we don't get it from the RPM)
+      gitinfo = %x[cd '#{source_path}' && git log -n 1].split("\n") rescue ['unknown']*3
+      gitcommit = gitinfo[0] || "unknown" rescue "unknown"
+      gitdate = gitinfo[2] || "unknown" rescue "unknown"
       if bc['git']
-        gitcommit = bc['git']['commit'] || 'unknown'
-        gitdate = bc['git']['date'] || 'unknown'
+        gitcommit = bc['git']['commit'] || gitcommit
+        gitdate = bc['git']['date'] || gitdate
       end
-      version = bc["version"] || '2.0'
-      build_version = bc["build_version"] || '2.0'
+      version = bc["version"] || '0.0'
+      build_version = bc["build_version"] || '0.0'
 
       source_url = bc["source_url"]
       barclamp.update_attributes!(:description   => bc['description'] || bc_name.humanize,

--- a/rails/app/views/barclamps/index.html.haml
+++ b/rails/app/views/barclamps/index.html.haml
@@ -10,6 +10,7 @@
         %th= t '.parent'
         %th= t '.description'
         %th= t '.roles'
+        %th= t '.commit'
     %tbody
       - @list.each do |bc|
         %tr.node{ :class => cycle(:odd, :even) }
@@ -22,3 +23,4 @@
           %td
             - bc.roles.each do |r|
               = link_to r.name, role_path(r.id)
+          %td= bc.commit

--- a/rails/app/views/barclamps/show.html.haml
+++ b/rails/app/views/barclamps/show.html.haml
@@ -5,6 +5,8 @@
   = dl_item t('.source_path'), @barclamp.source_path
   = dl_item t('.source_url'), link_to(@barclamp.source_url, @barclamp.source_url)
   = dl_item t('.version'), @barclamp.version
+  = dl_item t('.commit'), @barclamp.commit
+  = dl_item t('.build_on'), @barclamp.build_on
 
 %strong 
   %a.toggle.with_label{:href => "#", :id => "#data_toggle", :rel => "rawdata"}= t '.rawconfig'
@@ -18,3 +20,18 @@
 %h3= t '.roles'
 
 = render :partial => "roles/index", :locals => { :list => @barclamp.roles, :jig_name => nil }
+
+- githistory = %x[cd #{@barclamp.source_path} && git log -n 10].split("commit ") rescue nil
+
+- if githistory.length>0
+  %h3= "Git History"
+  %ol
+    - githistory.each do |commit|
+      - lines = commit.split("\n")
+      - if lines.length>0
+        %li
+          = lines[0]
+          %ul
+            - lines[1..1000].each do |l| 
+              - if l.length>0
+                %li= l

--- a/rails/app/views/layouts/application.html.haml
+++ b/rails/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
   %head
     %title= t 'title', default: "OpenCrowbar"
     = csrf_meta_tags
-    = stylesheet_link_tag 'application'
+    = stylesheet_link_tag Rails.configuration.crowbar.sass_base || 'application'
     /[if IE]
       = stylesheet_link_tag 'ie', :media => "all"
     = javascript_include_tag 'application'

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -31,6 +31,7 @@ module Crowbar
     # -- all .rb files in that directory are automatically loaded.
     config.crowbar = ActiveSupport::OrderedOptions.new 
     config.crowbar.version = '2.x'
+    config.crowbar.commit = %x[git log -n 1].split("\n")[0] rescue 'n/a'
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -31,7 +31,6 @@ module Crowbar
     # -- all .rb files in that directory are automatically loaded.
     config.crowbar = ActiveSupport::OrderedOptions.new 
     config.crowbar.version = '2.x'
-    config.crowbar.commit = %x[git log -n 1].split("\n")[0] rescue 'n/a'
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -215,6 +215,7 @@ en:
       parent: "Parent"
       description: "Description"
       roles: "Roles"
+      commit: "xRef"
     show:
       description: "Description"
       roles: "Roles"
@@ -222,6 +223,8 @@ en:
       source_url: "Source URL"
       version: "Version"
       rawconfig: "Raw Configuration"
+      commit: "Commit xRef"
+      build_on: "Date xRef"
   dashboard:
     list:
       title: "Bulk Edit Nodes"

--- a/rails/test/unit/barclamp_model_test.rb
+++ b/rails/test/unit/barclamp_model_test.rb
@@ -38,7 +38,7 @@ class BarclampModelTest < ActiveSupport::TestCase
   test "Versions" do
     b = Barclamp.find_or_create_by(:name=>"crowbar")
     assert_not_nil b
-    assert_equal 2.0, b.version.to_f
+    assert_equal 0.0, b.version.to_f
   end
 
   test "Naming Conventions" do


### PR DESCRIPTION
This allows engines to override the SASS directive.  NOTE: only 1 can win, so you can't do it in multiple engines.

Also, updated the docs and capture the git commit in the config.  Currently that is not exposed.