### PR TITLE
External fixes

### DIFF
--- a/chef/cookbooks/provisioner/files/default/start-up.sh
+++ b/chef/cookbooks/provisioner/files/default/start-up.sh
@@ -1,4 +1,74 @@
 #!/bin/bash
+
+export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+set -x
+set -e
+shopt -s extglob
+
+get_param() {
+    [[ $(cat /proc/cmdline) =~ $1 ]] && echo "${BASH_REMATCH[1]}"
+}
+
+# Stuff from sledgehammer file that makes this command debuggable
+# Some useful boot parameter matches
+ip_re='([0-9a-f.:]+/[0-9]+)'
+bootif_re='BOOTIF=([^ ]+)'
+host_re='crowbar\.fqdn=([^ ]+)'
+install_key_re='crowbar\.install\.key=([^ ]+)'
+provisioner_re='provisioner\.web=([^ ]+)'
+crowbar_re='crowbar\.web=([^ ]+)'
+domain_re='crowbar\.dns\.domain=([^ ]+)'
+dns_server_re='crowbar\.dns\.servers=([^ ]+)'
+
+# Grab the boot parameters we should always be passed
+
+# install key first
+export CROWBAR_KEY="$(get_param "$install_key_re")"
+
+# Provisioner and Crowbar web endpoints next
+export PROVISIONER_WEB="$(get_param "$provisioner_re")"
+export CROWBAR_WEB="$(get_param "$crowbar_re")"
+export DOMAIN="$(get_param "$domain_re")"
+export DNS_SERVERS="$(get_param "$dns_server_re")"
+
+if [[ $(cat /proc/cmdline) =~ $bootif_re ]]; then
+    MAC="${BASH_REMATCH[1]//-/:}"
+    MAC="${MAC#*:}"
+elif [[ -d /sys/firmware/efi ]]; then
+    declare -A boot_entries
+    bootent_re='^Boot([0-9]{4})'
+    efimac_re='MAC\(([0-9a-f]+)'
+    while read line; do
+        k="${line%% *}" 
+        v="${line#* }"
+        if [[ $k = BootCurrent:* ]]; then
+            current_bootent="${line##BootCurrent: }"
+        elif [[ $k =~ $bootent_re ]]; then
+            boot_entries["${BASH_REMATCH[1]}"]="$v"
+        fi
+    done < <(efibootmgr -v) 
+
+    if [[ ${boot_entries["$current_bootent"]} =~ $efimac_re ]]; then
+        MAC=''
+        for o in 0 2 4 6 8 10; do
+            MAC+="${BASH_REMATCH[1]:$o:2}:"
+        done
+        MAC=${MAC%:}
+    fi  
+fi
+for nic in /sys/class/net/*; do
+    [[ -f $nic/address && -f $nic/type && \
+        $(cat "$nic/type") = 1 && \
+        $(cat "$nic/address") = $MAC ]] || continue
+    BOOTDEV="${nic##*/}"
+    break
+done
+
+if [[ ! $BOOTDEV ]]; then
+    echo "We don't know what the MAC address of our boot NIC was!"
+    exit 1
+fi
+
 # Figure out where we PXE booted from.
 if ! [[ $(cat /proc/cmdline) =~ $host_re ]]; then
     export HOSTNAME="d${MAC//:/-}.${DOMAIN}"

--- a/chef/cookbooks/provisioner/providers/bootfile.rb
+++ b/chef/cookbooks/provisioner/providers/bootfile.rb
@@ -22,11 +22,12 @@ action :add do
   pxecfg_dir="#{discover_dir}/pxelinux.cfg"
   pxefile = "#{pxecfg_dir}/#{nodeaddr}"
   uefifile = "#{uefi_dir}/#{nodeaddr}.conf"
+  extra = (new_resource.bootenv == "local" ? "local." : "")
   template pxefile do
     mode 0644
     owner "root"
     group "root"
-    source "default.erb"
+    source "default.#{extra}erb"
     variables(:append_line => new_resource.kernel_params,
               :install_name => new_resource.bootenv,
               :initrd => new_resource.initrd,
@@ -41,7 +42,7 @@ action :add do
               :install_name => new_resource.bootenv,
               :initrd => new_resource.initrd,
               :kernel => new_resource.kernel)
-  end
+  end if new_resource.bootenv != "local"
 end
 
 action :remove do

--- a/chef/cookbooks/provisioner/providers/debian.rb
+++ b/chef/cookbooks/provisioner/providers/debian.rb
@@ -76,7 +76,7 @@ action :add do
     owner "root"
     group "root"
     source "crowbar_join.sh.erb"
-    variables(:admin_ip => provisioner_addr)
+    variables(:admin_ip => provisioner_addr, :name => mnode_name)
   end
 
   provisioner_bootfile mnode_name do

--- a/chef/cookbooks/provisioner/providers/fedora.rb
+++ b/chef/cookbooks/provisioner/providers/fedora.rb
@@ -61,7 +61,7 @@ action :add do
     owner "root"
     group "root"
     source "crowbar_join.sh.erb"
-    variables(:admin_ip => provisioner_addr)
+    variables(:admin_ip => provisioner_addr, :name => mnode_name)
   end
 
   provisioner_bootfile mnode_name do

--- a/chef/cookbooks/provisioner/providers/redhat.rb
+++ b/chef/cookbooks/provisioner/providers/redhat.rb
@@ -61,7 +61,7 @@ action :add do
     owner "root"
     group "root"
     source "crowbar_join.sh.erb"
-    variables(:admin_ip => provisioner_addr)
+    variables(:admin_ip => provisioner_addr, :name => mnode_name)
   end
 
   provisioner_bootfile mnode_name do

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -50,9 +50,9 @@ new_clients = {}
   case bootenv
   when "local"
     provisioner_bootfile mnode_name do
-      bootenv "sledgehammer"
+      bootenv "local"
       address v4addr
-      action :remove
+      action :add
     end
   when 'sledgehammer'
     pxe_params = node['crowbar']['provisioner']['server']['sledgehammer_kernel_params'].split(' ')

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.sh.erb
@@ -31,9 +31,6 @@ do
   sleep 1
 done
 
-# Get our hostname
-HOSTNAME=$(hostname -f)
-
 if [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
 fi
@@ -42,7 +39,7 @@ put_alive() {
     while ! curl -f -u "$CROWBAR_KEY" --digest -L -X PUT \
         -d "bootenv=local" \
         -d "alive=$1" \
-        "http://<%=@admin_ip%>:3000/api/v2/nodes/$HOSTNAME" &>/dev/null; do
+        "http://<%=@admin_ip%>:3000/api/v2/nodes/<%=@name%>" &>/dev/null; do
         sleep 1
     done
 }

--- a/chef/cookbooks/provisioner/templates/default/default.local.erb
+++ b/chef/cookbooks/provisioner/templates/default/default.local.erb
@@ -1,0 +1,5 @@
+DEFAULT local
+PROMPT 0
+TIMEOUT 10
+LABEL local
+  localboot 0

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -149,13 +149,13 @@ crowbar roles bind dns-database to "$FQDN"
 # Set the dns forwarder if you have them
 DNS_FORWARDER=""
 #DNS_FORWARDER="YOUR DNS IP HERE"
-ROLE_ID=`crowbar roles show dns-server | grep '"id"'`
-ROLE_ID=${ROLE_ID##*:}
-ROLE_ID=${ROLE_ID%,}
-NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 2' | grep \"id\"`
-NODE_ROLE_ID=${NODE_ROLE_ID##*:}
-NODE_ROLE_ID=${NODE_ROLE_ID%,}
 if [ "$DNS_FORWARDER" != "" ] ; then
+    ROLE_ID=`crowbar roles show dns-server | grep '"id"'`
+    ROLE_ID=${ROLE_ID##*:}
+    ROLE_ID=${ROLE_ID%,}
+    NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 2' | grep \"id\"`
+    NODE_ROLE_ID=${NODE_ROLE_ID##*:}
+    NODE_ROLE_ID=${NODE_ROLE_ID%,}
     crowbar noderoles set $NODE_ROLE_ID attrib dns-forwarders to "{ \"value\": [ \"$DNS_FORWARDER\" ] }"
 fi
 

--- a/crowbar-config.sh.ext_admin
+++ b/crowbar-config.sh.ext_admin
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Copyright 2014, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+date
+
+. /etc/profile
+cd /opt/opencrowbar/core
+. ./bootstrap.sh
+
+check_hostname
+
+[[ $FQDN ]] || export FQDN="$(hostname)"
+
+DOMAINNAME=${FQDN#*.}
+HOSTNAME=${FQDN%%.*}
+
+if [[ $http_proxy && !$upstream_proxy ]] && ! pidof squid; then
+    export upstream_proxy=$http_proxy
+fi
+
+# Update the provisioner server template to use whatever
+# proxy the admin node should be using.
+if [[ $upstream_proxy ]]; then
+    crowbar roles set provisioner-server \
+        attrib provisioner-upstream_proxy \
+        to "{\"value\": \"${upstream_proxy}\"}"
+fi
+
+crowbar roles set provisioner-os-install \
+    attrib provisioner-target_os \
+    to '{"value": "centos-7.0.1406"}'
+
+set -e
+set -x
+admin_net='
+{
+  "name": "admin",
+  "deployment": "system",
+  "conduit": "1g0",
+  "ranges": [
+    {
+      "name": "admin",
+      "first": "192.168.124.10/24",
+      "last": "192.168.124.11/24"
+    },
+    {
+      "name": "host",
+      "first": "192.168.124.81/24",
+      "last": "192.168.124.254/24"
+    },
+    {
+      "name": "dhcp",
+      "first": "192.168.124.21/24",
+      "last": "192.168.124.80/24"
+    }
+  ],
+  "router": {
+    "address": "192.168.124.10/24",
+    "pref": "10"
+  }
+}'
+
+bmc_net='
+{
+  "name": "bmc",
+  "deployment": "system",
+  "conduit": "bmc",
+  "ranges": [
+    {
+      "conduit": "1g0",
+      "name": "admin",
+      "first": "192.168.128.10/24",
+      "last": "192.168.128.20/24"
+    },
+    {
+      "name": "host",
+      "first": "192.168.128.21/24",
+      "last": "192.168.128.254/24"
+    }
+  ],
+  "router": {
+    "address": "192.168.128.10/24",
+    "pref": "99"
+  }
+}'
+
+
+admin_node="
+{
+  \"name\": \"$FQDN\",
+  \"admin\": true,
+  \"alive\": false,
+  \"bootenv\": \"local\"
+}
+"
+
+###
+# This should vanish once we have a real bootstrapping story.
+###
+ip_re='([0-9a-f.:]+/[0-9]+)'
+
+# Add required or desired services
+crowbar roles bind dns-service to "system-phantom.internal.local"
+crowbar roles bind ntp-service to "system-phantom.internal.local"
+crowbar roles bind dns-mgmt_service to "system-phantom.internal.local"
+
+# Set the domain name to use to the derived one
+ROLE_ID=`crowbar roles show dns-service | grep '"id"'`
+ROLE_ID=${ROLE_ID##*:}
+ROLE_ID=${ROLE_ID%,}
+NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 1' | grep \"id\"`
+NODE_ROLE_ID=${NODE_ROLE_ID##*:}
+NODE_ROLE_ID=${NODE_ROLE_ID%,}
+crowbar noderoles set $NODE_ROLE_ID attrib dns-domain to "{ \"value\": \"$DOMAINNAME\" }"
+
+crowbar nodes commit "system-phantom.internal.local"
+
+# Create a stupid default admin network
+crowbar networks create "$admin_net"
+
+# Create the equally stupid BMC network
+crowbar networks create "$bmc_net"
+
+# Create the admin node entry.
+crowbar nodes create "$admin_node"
+
+# Bind the admin role to it, and commit the resulting
+# proposed noderoles.
+
+# TODO: One day do it this way:
+# Setup DNS Server and Mgmt Shim for our own DNS Server
+# crowbar roles bind dns-server to "$FQDN"
+# crowbar roles bind dns-mgmt_shim_crowbar_dns to "$FQDN"
+# crowbar roles bind dns-database to "$FQDN"
+
+# Set the dns forwarder if you have them
+DNS_FORWARDER=""
+#DNS_FORWARDER="YOUR DNS IP HERE"
+if [ "$DNS_FORWARDER" != "" ] ; then
+    ROLE_ID=`crowbar roles show dns-server | grep '"id"'`
+    ROLE_ID=${ROLE_ID##*:}
+    ROLE_ID=${ROLE_ID%,}
+    NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 2' | grep \"id\"`
+    NODE_ROLE_ID=${NODE_ROLE_ID##*:}
+    NODE_ROLE_ID=${NODE_ROLE_ID%,}
+    crowbar noderoles set $NODE_ROLE_ID attrib dns-forwarders to "{ \"value\": [ \"$DNS_FORWARDER\" ] }"
+fi
+
+# Example external dns server - use instead of dns-database above
+curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "192.168.124.11", "Service": {"Service": "dns-service", "Port": 43, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+
+# Ntp Service configuration
+# Use the admin node as the ntp server for the cluster
+#crowbar roles bind ntp-server to "$FQDN"
+
+# Example external ntp server - use instead of ntp-server above
+curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "192.168.124.11", "Service": {"Service": "ntp-service", "Port": 123, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+
+# Setup DHCP Server - this can be optional
+#
+# If not used, the external DHCP server will need
+# to use the ADMIN NODE IP as the next server
+# and serve grub or pxelinux image.
+#
+# Here is an ISC DHCP Server stanza to use for an external dhcp server.
+# ++++++++
+# subnet 192.168.124.0 netmask 255.255.255.0 {
+#   option routers 192.168.124.10;  # Router here
+#   option subnet-mask 255.255.255.0;
+#   option broadcast-address 192.168.124.255;
+#   option domain-name "neode.com";
+#   option domain-name-servers 192.168.124.10; # Admin IP/DNS Server IP
+#   default-lease-time 7200;
+#   max-lease-time 36000;
+#    pool {
+#      range 192.168.124.81 192.168.124.254;   # Host Range from your Admin Network.
+#      allow unknown-clients;
+#      if option arch = 00:07 or option arch = 00:09 {
+#        filename = "grub-x86_64.efi";
+#      } else {
+#        filename = "grub.pxe";
+#      }
+#      next-server 192.168.124.10;            # Admin IP/Provisioner IP
+#    }
+# }
+# ++++++++
+#
+# Comment out this line if using your own DHCP server
+#crowbar roles bind dhcp-database to "$FQDN"
+
+# Setup Up provisioner.
+crowbar roles bind provisioner-database to "$FQDN"
+crowbar roles bind provisioner-repos to "$FQDN"
+crowbar roles bind provisioner-docker-setup to "$FQDN"
+
+# Add the now mostly empty admin-node
+crowbar roles bind crowbar-admin-node to "$FQDN"
+crowbar nodes commit "$FQDN"
+
+# Figure out what IP addresses we should have, and add them.
+netline=$(crowbar nodes addresses "$FQDN" on admin)
+nets=(${netline//,/ })
+for net in "${nets[@]}"; do
+    [[ $net =~ $ip_re ]] || continue
+    net=${BASH_REMATCH[1]}
+    # Make this more complicated and exact later.
+    ip addr add "$net" dev eth0 || :
+    echo "${net%/*} $FQDN" >> /etc/hosts || :
+done
+
+# Now that we have shiny new IP addresses, make sure that Squid has the right
+# addresses in place for always_direct exceptions, and pick up the new proxy
+# environment variables.
+
+(
+    . bootstrap.sh
+    chef-solo -c /opt/opencrowbar/core/bootstrap/chef-solo.rb -o "${proxy_recipes}"
+)
+. /etc/profile
+
+# Make sure that Crowbar is running with the proper environment variables
+service crowbar stop
+service crowbar start
+
+# flag allows you to stop before final step
+if ! [[ $* = *--zombie* ]]; then
+
+  # Mark the node as alive.
+  crowbar nodes update "$FQDN" '{"alive": true}'
+  #curl -s -f --digest -u $(cat /etc/crowbar.install.key) \
+  #    -X PUT "http://localhost:3000/api/v2/nodes/$FQDN" \
+  #    -d 'alive=true'
+  echo "Configuration Complete, you can watch annealing from the UI.  \`su - crowbar\` to begin managing the system."
+  # Converge the admin node.
+  crowbar converge && date
+else
+  echo "To complete configuration, mark node alive using: crowbar nodes update 1 '{""alive"": true}'"
+fi

--- a/crowbar-config.sh.ext_services
+++ b/crowbar-config.sh.ext_services
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Copyright 2014, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+date
+
+. /etc/profile
+cd /opt/opencrowbar/core
+. ./bootstrap.sh
+
+check_hostname
+
+[[ $FQDN ]] || export FQDN="$(hostname)"
+
+DOMAINNAME=${FQDN#*.}
+HOSTNAME=${FQDN%%.*}
+
+if [[ $http_proxy && !$upstream_proxy ]] && ! pidof squid; then
+    export upstream_proxy=$http_proxy
+fi
+
+# Update the provisioner server template to use whatever
+# proxy the admin node should be using.
+if [[ $upstream_proxy ]]; then
+    crowbar roles set provisioner-server \
+        attrib provisioner-upstream_proxy \
+        to "{\"value\": \"${upstream_proxy}\"}"
+fi
+
+crowbar roles set provisioner-os-install \
+    attrib provisioner-target_os \
+    to '{"value": "centos-7.0.1406"}'
+
+set -e
+set -x
+admin_net='
+{
+  "name": "admin",
+  "deployment": "system",
+  "conduit": "1g0",
+  "ranges": [
+    {
+      "name": "admin",
+      "first": "192.168.124.11/24",
+      "last": "192.168.124.12/24"
+    },
+    {
+      "name": "host",
+      "first": "192.168.124.81/24",
+      "last": "192.168.124.254/24"
+    },
+    {
+      "name": "dhcp",
+      "first": "192.168.124.21/24",
+      "last": "192.168.124.80/24"
+    }
+  ],
+  "router": {
+    "address": "192.168.124.10/24",
+    "pref": "10"
+  }
+}'
+
+bmc_net='
+{
+  "name": "bmc",
+  "deployment": "system",
+  "conduit": "bmc",
+  "ranges": [
+    {
+      "conduit": "1g0",
+      "name": "admin",
+      "first": "192.168.128.10/24",
+      "last": "192.168.128.20/24"
+    },
+    {
+      "name": "host",
+      "first": "192.168.128.21/24",
+      "last": "192.168.128.254/24"
+    }
+  ],
+  "router": {
+    "address": "192.168.128.10/24",
+    "pref": "99"
+  }
+}'
+
+
+admin_node="
+{
+  \"name\": \"$FQDN\",
+  \"admin\": true,
+  \"alive\": false,
+  \"bootenv\": \"local\"
+}
+"
+
+###
+# This should vanish once we have a real bootstrapping story.
+###
+ip_re='([0-9a-f.:]+/[0-9]+)'
+
+# Add required or desired services
+crowbar roles bind dns-service to "system-phantom.internal.local"
+crowbar roles bind ntp-service to "system-phantom.internal.local"
+crowbar roles bind dns-mgmt_service to "system-phantom.internal.local"
+
+# Set the domain name to use to the derived one
+ROLE_ID=`crowbar roles show dns-service | grep '"id"'`
+ROLE_ID=${ROLE_ID##*:}
+ROLE_ID=${ROLE_ID%,}
+NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 1' | grep \"id\"`
+NODE_ROLE_ID=${NODE_ROLE_ID##*:}
+NODE_ROLE_ID=${NODE_ROLE_ID%,}
+crowbar noderoles set $NODE_ROLE_ID attrib dns-domain to "{ \"value\": \"$DOMAINNAME\" }"
+
+crowbar nodes commit "system-phantom.internal.local"
+
+# Create a stupid default admin network
+crowbar networks create "$admin_net"
+
+# Create the equally stupid BMC network
+crowbar networks create "$bmc_net"
+
+# Create the admin node entry.
+crowbar nodes create "$admin_node"
+
+# Bind the admin role to it, and commit the resulting
+# proposed noderoles.
+
+# TODO: One day do it this way:
+# Setup DNS Server and Mgmt Shim for our own DNS Server
+# crowbar roles bind dns-server to "$FQDN"
+# crowbar roles bind dns-mgmt_shim_crowbar_dns to "$FQDN"
+crowbar roles bind dns-database to "$FQDN"
+
+# Set the dns forwarder if you have them
+DNS_FORWARDER="209.18.47.61"
+#DNS_FORWARDER="YOUR DNS IP HERE"
+if [ "$DNS_FORWARDER" != "" ] ; then
+    ROLE_ID=`crowbar roles show dns-server | grep '"id"'`
+    ROLE_ID=${ROLE_ID##*:}
+    ROLE_ID=${ROLE_ID%,}
+    NODE_ROLE_ID=`crowbar noderoles list | grep -B2 -A2 "\"role_id\":$ROLE_ID" | grep -B3 -A2 '"node_id": 2' | grep \"id\"`
+    NODE_ROLE_ID=${NODE_ROLE_ID##*:}
+    NODE_ROLE_ID=${NODE_ROLE_ID%,}
+    crowbar noderoles set $NODE_ROLE_ID attrib dns-forwarders to "{ \"value\": [ \"$DNS_FORWARDER\" ] }"
+fi
+
+# Example external dns server - use instead of dns-database above
+#curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "209.18.47.61", "Service": {"Service": "dns-service", "Port": 43, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+
+# Ntp Service configuration
+# Use the admin node as the ntp server for the cluster
+crowbar roles bind ntp-server to "$FQDN"
+
+# Example external ntp server - use instead of ntp-server above
+#curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "pool.ntp.org", "Service": {"Service": "ntp-service", "Port": 123, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+
+# Setup DHCP Server - this can be optional
+#
+# If not used, the external DHCP server will need
+# to use the ADMIN NODE IP as the next server
+# and serve grub or pxelinux image.
+#
+# Here is an ISC DHCP Server stanza to use for an external dhcp server.
+# ++++++++
+# subnet 192.168.124.0 netmask 255.255.255.0 {
+#   option routers 192.168.124.10;  # Router here
+#   option subnet-mask 255.255.255.0;
+#   option broadcast-address 192.168.124.255;
+#   option domain-name "neode.com";
+#   option domain-name-servers 192.168.124.10; # Admin IP/DNS Server IP
+#   default-lease-time 7200;
+#   max-lease-time 36000;
+#    pool {
+#      range 192.168.124.81 192.168.124.254;   # Host Range from your Admin Network.
+#      allow unknown-clients;
+#      if option arch = 00:07 or option arch = 00:09 {
+#        filename = "grub-x86_64.efi";
+#      } else {
+#        filename = "grub.pxe";
+#      }
+#      next-server 192.168.124.10;            # Admin IP/Provisioner IP
+#    }
+# }
+# ++++++++
+#
+# Comment out this line if using your own DHCP server
+crowbar roles bind dhcp-database to "$FQDN"
+
+# Setup Up provisioner.
+crowbar roles bind provisioner-database to "$FQDN"
+crowbar roles bind provisioner-repos to "$FQDN"
+crowbar roles bind provisioner-docker-setup to "$FQDN"
+
+# Add the now mostly empty admin-node
+crowbar roles bind crowbar-admin-node to "$FQDN"
+crowbar nodes commit "$FQDN"
+
+# Figure out what IP addresses we should have, and add them.
+netline=$(crowbar nodes addresses "$FQDN" on admin)
+nets=(${netline//,/ })
+for net in "${nets[@]}"; do
+    [[ $net =~ $ip_re ]] || continue
+    net=${BASH_REMATCH[1]}
+    # Make this more complicated and exact later.
+    ip addr add "$net" dev eth0 || :
+    echo "${net%/*} $FQDN" >> /etc/hosts || :
+done
+
+# Now that we have shiny new IP addresses, make sure that Squid has the right
+# addresses in place for always_direct exceptions, and pick up the new proxy
+# environment variables.
+
+(
+    . bootstrap.sh
+    chef-solo -c /opt/opencrowbar/core/bootstrap/chef-solo.rb -o "${proxy_recipes}"
+)
+. /etc/profile
+
+# Make sure that Crowbar is running with the proper environment variables
+service crowbar stop
+service crowbar start
+
+# flag allows you to stop before final step
+if ! [[ $* = *--zombie* ]]; then
+
+  # Mark the node as alive.
+  crowbar nodes update "$FQDN" '{"alive": true}'
+  #curl -s -f --digest -u $(cat /etc/crowbar.install.key) \
+  #    -X PUT "http://localhost:3000/api/v2/nodes/$FQDN" \
+  #    -d 'alive=true'
+  echo "Configuration Complete, you can watch annealing from the UI.  \`su - crowbar\` to begin managing the system."
+  # Converge the admin node.
+  crowbar converge && date
+else
+  echo "To complete configuration, mark node alive using: crowbar nodes update 1 '{""alive"": true}'"
+fi

--- a/script/roles/provisioner-os-install/01-install-os.sh
+++ b/script/roles/provisioner-os-install/01-install-os.sh
@@ -40,7 +40,7 @@ done < <(tac /proc/partitions)
 
 
 while true; do
-    curl -s -f -L -o /tmp/bootstate "$webserver/nodes/$(hostname -f)/bootstate" && \
+    curl -s -f -L -o /tmp/bootstate "$webserver/nodes/$HOSTNAME/bootstate" && \
         [[ -f /tmp/bootstate && $(cat /tmp/bootstate) = *-install ]] && break
     sleep 1
 done


### PR DESCRIPTION
These commits address issues with the external services.
1. Fixes issues with removing grub as bootloader.  (add local disk support to pxelinux)
2. Allow DNS names to not be registered for nodes.
3. Add debugging / retry ability to crowbar start-up.sh script
4. Add example files for testing external services with crowbar fronting crowbar.