### PR TITLE
Fix EULA button link

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -15,6 +15,8 @@
 
 version: "2.Camshaft"
 source_url: "https://github.com/opencrowbar/core"
+license: "Apache 2"
+license_url: "https://github.com/opencrowbar/core/blob/develop/doc/licenses/README.md"
 
 os_support:
   - ubuntu-12.04

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-version: "2.Camshaft"
+version: "2.Drill"
 source_url: "https://github.com/opencrowbar/core"
 license: "Apache 2"
 license_url: "https://github.com/opencrowbar/core/blob/develop/doc/licenses/README.md"

--- a/rails/app/controllers/docs_controller.rb
+++ b/rails/app/controllers/docs_controller.rb
@@ -18,6 +18,20 @@ class DocsController < ApplicationController
   # no login required for docs!
   skip_before_filter :crowbar_auth
 
+  # render licenses details for login
+  def eula
+    @file = Rails.configuration.crowbar.eula_base || '../doc/licenses/README.md'
+    if File.exist? @file
+      @raw = IO.read(@file)
+      fix_encoding! unless @raw.valid_encoding?
+      @raw.encode!('UTF-8', :invalid=>:replace)
+      @text = Maruku.new(@raw).to_html
+    else
+      @text = "#{I18n.t('.topic_missing', :scope=>'docs.topic')}: #{@file}"
+    end
+    render :show
+  end
+
   def index
     if params.has_key?(:rebuild)
         Doc.delete_all 

--- a/rails/app/controllers/support_controller.rb
+++ b/rails/app/controllers/support_controller.rb
@@ -19,6 +19,9 @@ class SupportController < ApplicationController
   skip_before_filter :crowbar_auth, :only => :digest
   before_filter :digest_auth!, :only => :digest
 
+  def eula
+  end
+  
   # used to pass a string into the debug logger to help find specificall calls  
   def marker
     Rails.logger.info "\nMARK >>>>> #{params[:id]} <<<<< KRAM\n"

--- a/rails/app/views/devise/sessions/new.html.haml
+++ b/rails/app/views/devise/sessions/new.html.haml
@@ -1,6 +1,6 @@
 %p#add_button{:style => 'float:right'}
   - license = t('user.license')
-  = link_to t('user.eula', :default=>license), docs_path(:id=>'framework/licenses'), :class => 'button', :id=>'eula_button'
+  = link_to t('user.eula', :default=>license), eula_path, :class => 'button', :id=>'eula_button'
 %h1= t 'user.sign_in'
 
 %section.box#login

--- a/rails/app/views/docs/show.html.haml
+++ b/rails/app/views/docs/show.html.haml
@@ -21,8 +21,7 @@
     %ol
       - @doc.children.sort.each do |c|
         %li= link_to c.description, doc_path(c.id)
-
-
+        
 - if @doc and current_user and current_user.settings(:ui).debug
   %hr
     %h3= t 'debug'

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -43,6 +43,7 @@ Crowbar::Application.routes.draw do
     put :recall
 
   end
+  get 'docs/eula' => 'docs#eula', as: :eula
   resources :docs, constraints: {id: /[^\?]*/}
 
   resources :groups


### PR DESCRIPTION
The license accept link was not correct.  

This approach uses a dedicated path for EULA and allows to overriding the path.