### PR TITLE
Diplomat tweaks

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -43,7 +43,7 @@ gem 'net-ssh'
 gem 'chef', ">= 11.16.4", '< 12.0'
 gem 'open4'
 gem 'structurematch', '~> 0.1.1'
-gem 'diplomat', '>= 0.2.2'
+gem 'diplomat'
 
 group :development, :test do
   gem 'coveralls'

--- a/rails/app/models/service.rb
+++ b/rails/app/models/service.rb
@@ -26,7 +26,7 @@ class Service < Role
       begin
         count += 1
         break if count > 20
-        pieces = Diplomat::Service.get(service_name, :all, options, meta)
+        pieces = ConsulAccess.getService(service_name, :all, options, meta)
         if pieces and pieces.empty?
           Rails.logger.info("#{service_name} not available ... wait 10m or next update")
           runlog << "#{service_name} not available ... wait 10m or next update"

--- a/rails/lib/consul_access.rb
+++ b/rails/lib/consul_access.rb
@@ -1,0 +1,45 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");.
+# you may not use this file except in compliance with the License..
+# You may obtain a copy of the License at.
+#
+#  http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software.
+# distributed under the License is distributed on an "AS IS" BASIS,.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied..
+# See the License for the specific language governing permissions and.
+# limitations under the License..
+#
+#
+
+class ConsulAccess
+
+  # We assume that consul is running locally.
+  # The proxy configuration may get in the way and prevent access.
+  # Force the rails app to not use a proxy to talk to the local
+  # consul agent or any agent really
+  def self.my_faraday_connection
+    conn = Faraday.new(:url => Diplomat.configuration.url, :proxy => {
+                                                             :uri      => '',
+                                                             :user     => '',
+                                                             :password => ''
+                                                         }) do |faraday|
+      faraday.request  :url_encoded
+      Diplomat.configuration.middleware.each do |middleware|
+        faraday.use middleware
+      end
+      faraday.adapter  Faraday.default_adapter
+      faraday.use      Faraday::Response::RaiseError
+    end
+    conn
+  end
+
+  # Wrap the Diplomat access to set common config/values
+  def self.getService(service_name, scope = :first, options = {}, meta = {})
+    Diplomat::Service.new(my_faraday_connection).get(service_name, scope, options, meta)
+  end
+
+end
+


### PR DESCRIPTION
Diplomat doesn't play well with proxies and no_proxy.  So, force the core app to use no proxy for diplomat calls.

This is annoying and may push write our own, but that still seems like more work.