### PR TITLE
update Ubuntu name connected to #532

### DIFF
--- a/chef/roles/provisioner-base-images/role-template.json
+++ b/chef/roles/provisioner-base-images/role-template.json
@@ -37,7 +37,7 @@
                         "kernel": "install/netboot/ubuntu-installer/amd64/linux",
                         "append": "debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us netcfg/dhcp_timeout=120 netcfg/choose_interface=auto root=/dev/ram rw quiet --",
                         "online_mirror": "http://us.archive.ubuntu.com/ubuntu/",
-                        "iso_file": "ubuntu-14.04.1-server-amd64.iso",
+                        "iso_file": "ubuntu-14.04.2-server-amd64.iso",
                         "codename": "trusty"
                     },
                     "debian-7.8.0": {


### PR DESCRIPTION
Ubuntu dropped 14.04.1 in favor of 14.04.2.

Tested through full install pass.