### PR TITLE
make consul URL configurable

### DIFF
--- a/BDD/consul.erl
+++ b/BDD/consul.erl
@@ -20,7 +20,7 @@
 
 g(Item) ->
   case Item of
-    server -> "http://127.0.0.1:8500";
+    server -> bdd_utils:config(consul_url,"http://127.0.0.1:8500");
     keypath -> "v1/kv";
     servicepath -> "v1/catalog/service";
     nodepath -> "v1/catalog/node";

--- a/BDD/example.config
+++ b/BDD/example.config
@@ -11,3 +11,4 @@
 {coverage_out,"/tmp/bdd_results.html"}.
 {marker_url,"utils/marker"}.
 {cli,"cd ../bin && ./crowbar"}.
+{consul_url,"http://127.0.0.1:8500"}.

--- a/doc/development-guides/testing/bdd/internals/config.md
+++ b/doc/development-guides/testing/bdd/internals/config.md
@@ -107,6 +107,13 @@ BDD selects the `default.config` file automatically.  You can choose which confi
     <td>["dns-service", "ntp-service","dns-mgmt_service"]</td>
     <td>Used by Crowbar to set the name of the phantom roles</td>
   </tr>
+  <tr>
+    <td>consul_url</td>
+    <td>no</td>
+    <td>http://127.0.0.1:8500</td>
+    <td>Used by Crowbar to set the consul server location</td>
+  </tr>
+
 </table>
 
 


### PR DESCRIPTION
allows users to change the location of the consul server. 

This is handy if you want to use the new no ports feature of the container and then talk directly to the containers IP address instead of assuming the ports are mapped.