### PR TITLE
added route for API Digest Auth (duplicates similar on UI)

### DIFF
--- a/doc/development-guides/api/README.md
+++ b/doc/development-guides/api/README.md
@@ -53,6 +53,8 @@ API callers use digest authentication for all requests. User accounts
 need to be specifically configured for API only access.  A user
 account with API access will still be able to log in normally.
 
+To get the digest, make a HEAD or GET request to /api/v2/digest
+
 #### Common API URL Patterns:
 
 OpenCrowbar uses a versioned URL pattern. By convention, resources

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -216,7 +216,7 @@ Crowbar::Application.routes.draw do
             delete "lock", :controller => "users", :action => "unlock"
             put "reset_password", :controller => "users", :action => "reset_password"
           end
-
+          get 'digest'        => "support#digest"
         end # version
       end # api
     end # id constraints


### PR DESCRIPTION
Minor item needed for API-Driven Metal.  We don't want to force people to use any non-api/v2 URLs.

In this case, the first URL that the API should hit is a HEAD request for /api/v2/digest to get the auth credentials.