### PR TITLE
allow node lookup by alias as backup for name or id

### DIFF
--- a/BDD/features/node.feature
+++ b/BDD/features/node.feature
@@ -50,6 +50,16 @@ Feature: Nodes
   Scenario: REST Get 404
     When REST gets the {object:node} "thisdoesnotexist"
     Then I get a {integer:404} error
+
+  Scenario: REST Get Alias
+    Given REST creates the {object:node} "insert.witty.alias"
+      And REST sets the {object:node} "insert.witty.alias" "alias" state to be "witty"
+    When REST gets the {object:node} "witty"
+    Then I get a {integer:200} result
+      And the {object:node} is properly formatted
+      And key "name" is "insert.witty.alias"
+      And key "alias" is "witty"
+    Finally REST removes the {object:node} "insert.witty.alias"
     
   Scenario: Node List
     Given there is a {object:node} "bdd-node-list.example.com"

--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -61,7 +61,7 @@ class NodesController < ApplicationController
   end
 
   def show
-    @node = Node.find_key params[:id]
+    @node = Node.find_key(params[:id]) rescue Node.find_by(alias: params[:id])
     respond_to do |format|
       format.html {  } # show.html.erb
       format.json { render api_show @node }


### PR DESCRIPTION
small tweak (with tests) so that we can use the node alias as a backup for the name or ID

needed for DockerMachine