### PR TITLE
Add a separate high-priority run queue.

### DIFF
--- a/etc/init.d/crowbar
+++ b/etc/init.d/crowbar
@@ -49,6 +49,11 @@ as_crowbar() (
 )
 
 start(){
+    if status; then
+        echo "Crowbar is already running"
+        return 1
+    fi
+    rm /opt/opencrowbar/core/rails/tmp/pids/*
     if [[ $OS = suse ]]; then
         # refresh the Gemfile.lock content before starting the server
         # (outdated file can cause problems after any of the required
@@ -59,17 +64,20 @@ start(){
     as_crowbar bundle exec puma -d -C $PUMA_CFG
     echo "Starting delayed_job NodeRoleRunner queue (10 workers)"
     as_crowbar bundle exec script/delayed_job --queue=NodeRoleRunner -n 10 start
+    as_crowbar bundle exec script/delayed_job --queue=HighPriorityRunner start
     as_crowbar bundle exec script/dj_reaper start
 }
 
 stop() {
     as_crowbar bundle exec pumactl -F $PUMA_CFG stop
+    as_crowbar bundle exec script/delayed_job -n 10 stop
     as_crowbar bundle exec script/delayed_job stop
     as_crowbar bundle exec script/dj_reaper stop
 }
 
 restart() {
     as_crowbar bundle exec pumactl -F $PUMA_CFG restart
+    as_crowbar bundle exec script/delayed_job -n 10 restart
     as_crowbar bundle exec script/delayed_job restart
     as_crowbar bundle exec script/dj_reaper restart
 }

--- a/rails/db/migrate/20150504102000_save_queue_in_runs.rb
+++ b/rails/db/migrate/20150504102000_save_queue_in_runs.rb
@@ -1,0 +1,24 @@
+# Copyright 2015, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class SaveQueueInRuns < ActiveRecord::Migration
+
+  def change
+    change_table :runs do |t|
+      t.string   :queue, default: "NodeRoleRunner"
+    end
+  end
+
+end


### PR DESCRIPTION
This queue is only for runs enrolled with Run.enqueue, and should help
ensure that runs that spin waiiting on certian critical roles (like the
provisioner and dhcp database roles) do not wind up deadlocking the
runner by occupying all the delayed_jobs backend workers.