### PR TITLE
Crowbar access script

### DIFF
--- a/barclamps/chef.yml
+++ b/barclamps/chef.yml
@@ -38,7 +38,6 @@ roles:
     description: 'Provides a chef client.'
     requires:
       - chef-server
-      - crowbar-access
     flags:
       - implicit
     attribs:

--- a/barclamps/chef.yml
+++ b/barclamps/chef.yml
@@ -38,6 +38,7 @@ roles:
     description: 'Provides a chef client.'
     requires:
       - chef-server
+      - crowbar-access
     flags:
       - implicit
     attribs:

--- a/barclamps/crowbar.yml
+++ b/barclamps/crowbar.yml
@@ -22,6 +22,7 @@ roles:
       - milestone
       - implicit
     requires:
+      - crowbar-access
       - network-server
       - network-lldpd
       - crowbar-installed-node
@@ -33,6 +34,7 @@ roles:
       - implicit
       - powersave
     requires:
+      - crowbar-access
       - deployer-client
       - dns-client
       - logging-client
@@ -66,12 +68,15 @@ roles:
     requires:
       - provisioner-repos
       - provisioner-docker-setup
+      - crowbar-access
     provides:
       - crowbar-managed-node
       - crowbar-installed-node
   - name: crowbar-access
     description: "Crowbar Access Keys"
-    jig: noop
+    flags:
+      - implicit
+    jig: script
     attribs:
       - name: crowbar-machine_key
         description: 'The username and password that managed nodes should use to talk to the Crowbar API'
@@ -103,7 +108,6 @@ roles:
     jig: chef
     requires:
       - consul
-      - crowbar-access
   - name: crowbar-api_service
     jig: role-provided
     flags:
@@ -120,7 +124,6 @@ roles:
   - name: crowbar-job_runner
     jig: chef
     requires:
-      - crowbar-access
       - consul
   - name: crowbar-job_runner_service
     jig: role-provided
@@ -141,6 +144,8 @@ roles:
     flags:
       - milestone
       - implicit
+    requires:
+      - crowbar-access
     conflicts:
       - crowbar-managed-node
     provides:

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -168,7 +168,6 @@ crowbar networks create "$bmc_net"
 # Join the admin node into the rails app and make it manageable
 ./crowbar-node.sh 127.0.0.1
 
-crowbar roles bind crowbar-access to "$FQDN"
 # Build a map of keys in the /root/.ssh/authorized_keys
 # Record the machine key as well. -- THIS IS NOT GREAT
 if [ -e /root/.ssh/authorized_keys ] ; then
@@ -182,8 +181,9 @@ if [ -e /root/.ssh/authorized_keys ] ; then
         COMMA=","
     done
     echo "} }" >> /tmp/key_list
-    crowbar nodes set "$FQDN" attrib crowbar-access_keys to "`cat /tmp/key_list`"
-    crowbar nodes set "$FQDN" attrib crowbar-machine_key to "{ \"value\": \"`cat /etc/crowbar.install.key`\" }"
+    crowbar deploymentroles set crowbar-access attrib crowbar-access_keys to "`cat /tmp/key_list`"
+    crowbar deploymentroles set crowbar-access attrib crowbar-machine_key to "{ \"value\": \"`cat /etc/crowbar.install.key`\" }"
+    crowbar deploymentroles commit crowbar-access
     rm -rf /tmp/key_list
 fi
 

--- a/rails/app/models/deployment_role.rb
+++ b/rails/app/models/deployment_role.rb
@@ -25,7 +25,41 @@ class DeploymentRole < ActiveRecord::Base
   has_one    :barclamp, :through => :role
   has_many   :attribs, :through => :role
 
+  scope  :by_name,      -> (n)   { joins(:role).where('roles.name' => n) }
+
   # convenience methods
+
+  def self.find_key(key)
+    col,key = case
+                when db_id?(key) then [:id, key.to_i]
+                when key.is_a?(ActiveRecord::Base) then [:id, key.id]
+                when self.respond_to?(:name_column) then [name_column, key]
+                when key == "admin" then [:id,Node.find_by!(admin: true).id]
+                else [:name, key]
+              end
+
+    # Name is a made-up column, but search it anyway.
+    if col == :name
+      answer = self.by_name(key)
+      if !answer or answer.empty?
+        e = ActiveRecord::RecordNotFound.new
+        e.crowbar_model = self
+        e.crowbar_column = col
+        e.crowbar_key = key
+        raise e
+      end
+      return answer.first
+    end
+
+    begin
+      find_by!(col => key)
+    rescue ActiveRecord::RecordNotFound => e
+      e.crowbar_model = self
+      e.crowbar_column = col
+      e.crowbar_key = key
+      raise e
+    end
+  end
 
   def name
     role.name

--- a/script/roles/crowbar-access/01-crowbar-access.sh
+++ b/script/roles/crowbar-access/01-crowbar-access.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Clean out key file
+rm -f /root/.ssh/authorized_keys
+
+# Make file key file
+mkdir -p /root/.ssh
+echo "# Crowbar built file" >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+
+# Put keys in place
+key_names=$(get_keys "crowbar/access_keys")
+if [[ "${key_names}" != "" ]]; then
+    for name in $key_names
+    do
+      read_attribute "crowbar/access_keys/${name}" >> /root/.ssh/authorized_keys
+      echo >> /root/.ssh/authorized_keys
+    done
+fi
+
+# Put machine key in place
+rm -f /etc/crowbar.install.key
+read_attribute_file_content "crowbar/machine_key" "/etc/crowbar.install.key"
+chmod 644 /etc/crowbar.install.key
+


### PR DESCRIPTION
   Add the ability to set deployment roles by role name.
 
   Convert the crowbar-access role from noop to script
    
    Also make the role implicit and associated with the
    crowbar-managed node roles for inclusion.
    
    Set the default keys on the deployment role so that
    all nodes get it.
    
    This enables node specific keys as well.