### PR TITLE
Change the crowbar-access script to only update crowbar

### DIFF
--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -181,9 +181,9 @@ if [ -e /root/.ssh/authorized_keys ] ; then
         COMMA=","
     done
     echo "} }" >> /tmp/key_list
-    crowbar deploymentroles set crowbar-access attrib crowbar-access_keys to "`cat /tmp/key_list`"
-    crowbar deploymentroles set crowbar-access attrib crowbar-machine_key to "{ \"value\": \"`cat /etc/crowbar.install.key`\" }"
-    crowbar deploymentroles commit crowbar-access
+    crowbar deployments set system attrib crowbar-access_keys to "`cat /tmp/key_list`"
+    crowbar deployments set system attrib crowbar-machine_key to "{ \"value\": \"`cat /etc/crowbar.install.key`\" }"
+    crowbar deployments commit system
     rm -rf /tmp/key_list
 fi
 

--- a/rails/app/models/deployment_role.rb
+++ b/rails/app/models/deployment_role.rb
@@ -29,38 +29,6 @@ class DeploymentRole < ActiveRecord::Base
 
   # convenience methods
 
-  def self.find_key(key)
-    col,key = case
-                when db_id?(key) then [:id, key.to_i]
-                when key.is_a?(ActiveRecord::Base) then [:id, key.id]
-                when self.respond_to?(:name_column) then [name_column, key]
-                when key == "admin" then [:id,Node.find_by!(admin: true).id]
-                else [:name, key]
-              end
-
-    # Name is a made-up column, but search it anyway.
-    if col == :name
-      answer = self.by_name(key)
-      if !answer or answer.empty?
-        e = ActiveRecord::RecordNotFound.new
-        e.crowbar_model = self
-        e.crowbar_column = col
-        e.crowbar_key = key
-        raise e
-      end
-      return answer.first
-    end
-
-    begin
-      find_by!(col => key)
-    rescue ActiveRecord::RecordNotFound => e
-      e.crowbar_model = self
-      e.crowbar_column = col
-      e.crowbar_key = key
-      raise e
-    end
-  end
-
   def name
     role.name
   end

--- a/script/roles/crowbar-access/01-crowbar-access.sh
+++ b/script/roles/crowbar-access/01-crowbar-access.sh
@@ -1,25 +1,47 @@
 #!/bin/bash
 
-# Clean out key file
-rm -f /root/.ssh/authorized_keys
-
-# Make file key file
+# Make sure the key file is there
 mkdir -p /root/.ssh
-echo "# Crowbar built file" >> /root/.ssh/authorized_keys
-chmod 600 /root/.ssh/authorized_keys
+NEW_FILE="/tmp/tt.$$.ca"
+AUTH_FILE="/root/.ssh/authorized_keys"
 
 # Put keys in place
 key_names=$(get_keys "crowbar/access_keys")
+touch "${NEW_FILE}"
 if [[ "${key_names}" != "" ]]; then
     for name in $key_names
     do
-      read_attribute "crowbar/access_keys/${name}" >> /root/.ssh/authorized_keys
-      echo >> /root/.ssh/authorized_keys
+      read_attribute "crowbar/access_keys/${name}" >> "${NEW_FILE}"
+      echo >> "${NEW_FILE}"
     done
 fi
+sort -u "${NEW_FILE}" > "${NEW_FILE}.2"
 
-# Put machine key in place
-rm -f /etc/crowbar.install.key
-read_attribute_file_content "crowbar/machine_key" "/etc/crowbar.install.key"
-chmod 644 /etc/crowbar.install.key
+lead='^### BEGIN GENERATED CONTENT$'
+tail='^### END GENERATED CONTENT$'
+
+if ! grep -q "$lead" "${AUTH_FILE}" ; then
+  echo "### BEGIN GENERATED CONTENT" >> "${AUTH_FILE}"
+  echo "### END GENERATED CONTENT" >> "${AUTH_FILE}"
+fi
+
+sed -e "/$lead/,/$tail/{ /$lead/{p; r ${NEW_FILE}.2
+        }; /$tail/p; d }" "$AUTH_FILE" > "${NEW_FILE}.3"
+
+# Make the file contents uniq and only update if needed
+if ! diff -q "${NEW_FILE}.3" "${AUTH_FILE}" 2>&1 >/dev/null; then
+    cp "${NEW_FILE}.3" "${AUTH_FILE}"
+    chmod 600 "${AUTH_FILE}"
+fi
+rm -f "${NEW_FILE}" "${NEW_FILE}.2" "${NEW_FILE}.3"
+
+# Put machine key in place if changed or not present
+NEW_FILE="/tmp/tt.$$.ca"
+KEY_FILE="/etc/crowbar.install.key"
+read_attribute_file_content "crowbar/machine_key" "${NEW_FILE}"
+if ! diff -q "${NEW_FILE}" "${KEY_FILE}" 2>&1 >/dev/null; then
+    cp "${NEW_FILE}" "${KEY_FILE}"
+    chmod 600 "${KEY_FILE}"
+fi
+rm -f "${NEW_FILE}"
 


### PR DESCRIPTION
provided keys.

only update the files if they change.

Update the deployment role through the system deployment instead of
randomly choosing the first instance by name.

Remove bad find code.