### PR TITLE
This adds delete support for NodeRoles.

### DIFF
--- a/BDD/linux_test.sh
+++ b/BDD/linux_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+erl -s bdd test -s init stop -noshell

--- a/bin/ocb_console
+++ b/bin/ocb_console
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ $(whoami) != crowbar ]]; then
-    su -l -c "$0" crowbar
+    su -l -c "$0 $*" crowbar
     exit $?
 fi
 . /etc/profile

--- a/rails/app/controllers/attribs_controller.rb
+++ b/rails/app/controllers/attribs_controller.rb
@@ -18,6 +18,11 @@ class AttribsController < ApplicationController
   def index
     target = find_target
     @list = target.nil? ? Attrib.all : target.attribs
+    @list = @list.map do |i|
+      e = i.as_json
+      e["value"] = i.get(target)
+      e
+    end if target
     respond_to do |format|
       format.html { }
       format.json { render api_index :attrib, @list }

--- a/rails/app/controllers/deployment_roles_controller.rb
+++ b/rails/app/controllers/deployment_roles_controller.rb
@@ -72,7 +72,7 @@ class DeploymentRolesController < ApplicationController
     render api_delete @deployment_role
   end
 
-   def propose
+  def propose
     @deployment_role = DeploymentRole.find_key params[:deployment_role_id]
     @deployment_role.propose
     respond_to do |format|

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -109,11 +109,9 @@ class NodeRolesController < ApplicationController
   end
 
   def destroy
-    unless Rails.env.development?
-      render  api_not_supported("delete", "node_role")
-    else
-      render api_delete NodeRole
-    end
+    @node_role = NodeRole.find_key (params[:id] || params[:node_role_id])
+    @node_role.destroy
+    render api_delete @node_role
   end
 
   def propose

--- a/rails/app/models/deployment_role.rb
+++ b/rails/app/models/deployment_role.rb
@@ -114,6 +114,7 @@ class DeploymentRole < ActiveRecord::Base
   end
 
   def role_delete_hook
+    return false unless noderoles.count == 0
     role.on_deployment_delete(self)
   end
 

--- a/rails/app/models/node.rb
+++ b/rails/app/models/node.rb
@@ -44,7 +44,7 @@ class Node < ActiveRecord::Base
 
   # TODO: 'alias' will move to DNS BARCLAMP someday, but will prob hang around here a while
   validates_uniqueness_of :alias, :case_sensitive => false, :message => I18n.t("db.notunique", :default=>"Name item must be unique")
-  validates_format_of :alias, :with=>/\A[A-Za-z0-9\-]*[A-Za-z0-9]\z/, :message => I18n.t("db.alias", :default=>"Alias is not valid.")
+  validates_format_of :alias, :with=>/\A[a-zA-Z0-9_\-]{1,63}\z/, :message => I18n.t("db.alias", :default=>"Alias is not valid.")
   validates_length_of :alias, :maximum => 100
 
   has_and_belongs_to_many :groups, :join_table => "node_groups", :foreign_key => "node_id"

--- a/test.sh
+++ b/test.sh
@@ -48,10 +48,14 @@ chef-solo -c /opt/opencrowbar/core/bootstrap/chef-solo.rb -o "${database_recipes
 # Talk about tests
 echo
 echo "To run tests:"
+echo "yum -y install erlang"
 echo "su - crowbar"
 echo "cd rails"
 echo "bundle exec rake test"
 echo "bundle exec rspec"
+echo "cd ../BDD"
+echo "./linux_compile.sh"
+echo "./linux_test.sh"
 echo
 
 /bin/bash -i


### PR DESCRIPTION
The new rules for deleting things:

1. You can only delete noderoles that either:
   * Have no children
   * Have only children that are on the same node.
   * Have only children that are in PROPOSED and that have never run.
   These rules apply recursively down the noderole graph.

2. You can only delete deploymentroles that do not have noderoles
dependent on them.

3. Deleting a deployment deletes all the noderoles in it (using the
rules above, then the deploymentroles, then the phantom node for the
deployment, then it moves all the nodes to the deployment's parent.

All the new functionality has been exposed via the API (and the CLI),
bit not via the UI.  Deleting a thing via the CLI is accomplished using

    crowbar <objectclass> destroy <objectid>

This is intended to fix #574