### PR TITLE
Start enumerating out disks again

### DIFF
--- a/barclamps/crowbar.yml
+++ b/barclamps/crowbar.yml
@@ -227,3 +227,6 @@ attribs:
       sequence:
         - type: str
           pattern: '/([0-9a-fA-F]{2}:){5}[0-9a-fA-F]/'
+  - name: 'disks'
+    description: 'The disks present in the system'
+    map: 'reservations/disks'

--- a/chef/cookbooks/barclamp/libraries/disk.rb
+++ b/chef/cookbooks/barclamp/libraries/disk.rb
@@ -1,0 +1,168 @@
+class Disk
+
+  @@syspath = "/sys/block"
+  @@by_id = "/dev/disk/by-id"
+  @@id_sort_keys = [ /\/scsi-[a-zA-Z]/,
+                     /\/scsi-[^1]/,
+                     /\/scsi-/,
+                     /\/ata-/,
+                     /\/cciss-/,
+                     /\/wwn-/,
+                     /\/usb-/ ]
+  def self.update(node)
+    node.set[:crowbar_wall] = {} unless node[:crowbar_wall]
+    node.set[:crowbar_wall][:reservations] = {} unless node[:crowbar_wall][:reservations]
+    present_disks = Dir.glob("/sys/block/*").map do |ent|
+      new(ent)
+    end.reject do |ent|
+      ent.virtual || ent.readonly
+    end.sort.map do |ent|
+      ent.to_hash
+    end
+    Chef::Log.info("Current disks: #{present_disks.inspect}")
+    recorded_disks = node[:crowbar_wall][:reservations][:disks] || []
+    Chef::Log.info("Recorded disks: #{recorded_disks.inspect}")
+    disks = {}
+    # Record the current set of disks
+    present_disks.each_index do |i|
+      d = present_disks[i]
+      disks[d["unique_name"]]= { "current" => d, "index" => i }
+    end
+    recorded_disks.each do |d|
+      found_id = (disks.keys & d.ids).first
+      if found_id
+        # One of our ids is already used as a unique name.  Hooray.
+        disks[found_id]["recorded"] = d
+      elsif disks.key?(d["unique_name"])
+        # We don't have an ID that matches, but our unique name does.
+        # Hopefully they are referring to the same device
+        disks[d["unique_name"]]["recorded"] = d
+      end
+      # If we get through the if without hitting anything, this disk has vanished.
+    end
+    new_disks = disks.values.sort{|a,b| a["index"] <=> b["index"]}.map do |val|
+      if val.key?("recorded")
+        val["recorded"].merge(val["current"])
+      else
+        val["current"]
+      end
+    end
+    node.set[:crowbar_wall][:reservations][:disks] = new_disks
+  end
+
+  def initialize(dev)
+    @dev = dev.split("/")[-1]
+    bpath = nil
+    [ @@syspath, @@by_id ].each do |base|
+      next unless File.symlink?("#{base}/#{@dev}")
+      bpath = base
+
+    end
+    raise "#{dev} is not a device" unless bpath
+    if bpath == @@by_id
+      @dev = File.readlink("#{bpath}/#{@dev}").split("/")[-1]
+    end
+    @basepath = "#{@@syspath}/#{@dev}"
+  end
+
+  def ids
+    pathfind(@@by_id).sort do |a,b|
+      id_sort_key(a) <=> id_sort_key(b)
+    end
+  end
+
+  def path
+    File.expand_path(File.readlink(@basepath),@@syspath)
+  end
+
+  def unique_name
+    ids.push("/dev/#{@dev}").first
+  end
+
+  def <=>(other)
+    pp = self.pathparts
+    opp = other.pathparts
+    [pp.length, pp] <=> [opp.length, opp]
+  end
+
+  def removable
+    sysread("removable",:bool)
+  end
+
+  def readonly
+    sysread("ro",:bool)
+  end
+
+  def ssd
+    !sysread("queue/rotational",:bool)
+  end
+
+  def size
+    sysread("size",:integer) * 512
+  end
+
+  def usb
+    pathparts.any?{|c|/^usb/.match(c)}
+  end
+
+  def virtual
+    path.split("/").any?{|ent|ent =="virtual"}
+  end
+
+  def partitioned
+    !Dir.glob("#{@basepath}/#{@dev}[1-9]").empty?
+  end
+  
+  def held
+    !Dir.glob("#{@basepath}/holders").empty?
+  end
+
+  def formatted
+    %x{blkid -u filesystem -s UUID /dev/#{@dev}}.strip.length > 0
+  end
+
+  def to_hash
+    { "ids" => ids,
+      "unique_name" => unique_name,
+      "path" => path,
+      "usb" => usb,
+      "readonly" => readonly,
+      "ssd" => ssd,
+      "size" => size,
+      "removable" => removable,
+      "virtual" => virtual,
+      "partitioned" => partitioned,
+      "held" => held,
+      "formatted" => formatted,
+      "used" => held || partitioned || formatted
+    }
+  end
+
+  protected
+
+  def id_sort_key(dsk_id)
+    idx = @@id_sort_keys.index{|re|re.match(dsk_id)}
+    idx ||= 999
+    Chef::Log.info([idx,dsk_id].inspect)
+    return [idx,dsk_id]
+  end
+
+  def sysread(file,convert=:string)
+    data = IO.read(File.join(@basepath,file)).strip
+    case convert
+    when :bool then data != "0"
+    when :integer then data.to_i
+    when :string then data
+    end
+  end
+
+  def pathparts
+    File.readlink(@basepath).split("/")[2..-3]
+  end
+
+  def pathfind(prefix)
+    Dir.glob("#{prefix}/*").select do |ent|
+      File.symlink?(ent) && (File.readlink(ent).split("/")[-1] == @dev)
+    end
+  end
+end

--- a/chef/cookbooks/barclamp/libraries/disk.rb
+++ b/chef/cookbooks/barclamp/libraries/disk.rb
@@ -114,7 +114,7 @@ class Disk
   end
   
   def held
-    !Dir.glob("#{@basepath}/holders").empty?
+    !Dir.glob("#{@basepath}/holders/*").empty?
   end
 
   def formatted

--- a/chef/cookbooks/barclamp/recipes/default.rb
+++ b/chef/cookbooks/barclamp/recipes/default.rb
@@ -16,3 +16,5 @@
 class Chef::Recipe
   include ::BarclampLibrary
 end
+
+Disk.update(node)

--- a/rails/app/models/node_role.rb
+++ b/rails/app/models/node_role.rb
@@ -469,7 +469,7 @@ class NodeRole < ActiveRecord::Base
         res.deep_merge!(attr.extract(self,:all,true))
       end
       # Add information about the resource reservations this node has in place
-      unless node.discovery["reservations"]
+      if node.discovery["reservations"]
       res["crowbar_wall"] ||= Hash.new
         res["crowbar_wall"]["reservations"] = node.discovery["reservations"]
       end

--- a/rails/app/models/run.rb
+++ b/rails/app/models/run.rb
@@ -85,7 +85,7 @@ class NodeRoleRun < Que::Job
           next unless (this_nr.wall["crowbar_wall"]["reservations"] rescue nil)
           res.deep_merge!(this_nr.wall["crowbar_wall"]["reservations"])
           end
-        nr.node.discovery.merge({"reservations" => res})
+        nr.node.hint_update({"reservations" => res})
       end
     rescue StandardError => e
       to_error = true


### PR DESCRIPTION
Every time Chef runs, get the disks for the reservation framework.  We
don't just use the ohai information because it does not contain the
information we need in the format we want.