### PR TITLE
Feat/ubuntu 15.04

### DIFF
--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -150,6 +150,7 @@ roles:
           enum:
             - ubuntu-12.04
             - ubuntu-14.04
+            - ubuntu-15.04
             - redhat-6.5
             - redhat-6.6
             - centos-6.5

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -89,6 +89,14 @@ new_clients = {}
       rootdev root
       action :add
     end
+  when 'ubuntu-15.04-install'
+    provisioner_debian mnode_name do
+      distro 'ubuntu'
+      version '15.04'
+      address v4addr
+      target mnode_name
+      action :add
+    end
   when 'ubuntu-14.04-install'
     provisioner_debian mnode_name do
       distro 'ubuntu'

--- a/chef/roles/provisioner-base-images/role-template.json
+++ b/chef/roles/provisioner-base-images/role-template.json
@@ -32,6 +32,14 @@
                         "iso_file": "ubuntu-12.04.5-server-amd64.iso",
                         "codename": "precise"
                     },
+                    "ubuntu-15.04": {
+                        "initrd": "install/netboot/ubuntu-installer/amd64/initrd.gz",
+                        "kernel": "install/netboot/ubuntu-installer/amd64/linux",
+                        "append": "debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us netcfg/dhcp_timeout=120 netcfg/choose_interface=auto root=/dev/ram rw quiet --",
+                        "online_mirror": "http://us.archive.ubuntu.com/ubuntu/",
+                        "iso_file": "ubuntu-15.04-server-amd64.iso",
+                        "codename": "vivid"
+                    },
                     "ubuntu-14.04": {
                         "initrd": "install/netboot/ubuntu-installer/amd64/initrd.gz",
                         "kernel": "install/netboot/ubuntu-installer/amd64/linux",

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -20,6 +20,8 @@ license_url: "https://github.com/opencrowbar/core/blob/develop/doc/licenses/READ
 
 os_support:
   - ubuntu-12.04
+  - ubuntu-14.04
+  - ubuntu-15.04
   - redhat-6.5
   - redhat-6.6
   - centos-6.5
@@ -135,6 +137,26 @@ debs:
       - deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
       - deb http://get.docker.io/ubuntu docker main
       - deb http://ppa.launchpad.net/saltstack/salt/ubuntu trusty main
+      - deb http://download.draios.com/stable/deb stable-amd64/
+    pkgs:
+      - rpcbind
+  ubuntu-15.04:
+    raw_pkgs:
+      - http://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.14.2-1_amd64.deb
+    repos:
+      - deb http://us.archive.ubuntu.com/ubuntu/ vivid main restricted universe multiverse
+      - deb-src http://us.archive.ubuntu.com/ubuntu/ vivid main restricted universe multiverse
+      - deb http://us.archive.ubuntu.com/ubuntu/ vivid-updates main restricted universe multiverse
+      - deb-src http://us.archive.ubuntu.com/ubuntu/ vivid-updates main restricted universe multiverse
+      - deb http://archive.canonical.com/ubuntu vivid partner
+      - deb-src http://archive.canonical.com/ubuntu vivid partner
+      #- deb http://extras.ubuntu.com/ubuntu vivid main
+      #- deb-src http://extras.ubuntu.com/ubuntu vivid main
+      - deb http://security.ubuntu.com/ubuntu vivid-security main restricted universe multiverse
+      - deb-src http://security.ubuntu.com/ubuntu vivid-security main restricted universe multiverse
+      #- deb http://apt.postgresql.org/pub/repos/apt/ vivid-pgdg main
+      - deb http://get.docker.io/ubuntu docker main
+      - deb http://ppa.launchpad.net/saltstack/salt/ubuntu vivid main
       - deb http://download.draios.com/stable/deb stable-amd64/
     pkgs:
       - rpcbind


### PR DESCRIPTION
## Summary

This adds support for crowbar to install ubuntu 15.04.

## Notes

Tested with basic provisioning. I only grabbed some supermicro cloud blades and tried this out on a few nodes. I noticed that the blade doesn't reboot for any iso, so I'm eager to hear reports this works for others flawlessly. I had no problems using the standard kickstart files.

## Todos and misses

This will likely need tweaks things for systemd in the future, so consider this feature 'beta ready' if you intend to do a lot of roles on top of it. I trust chef will do its best, and many 'service <name> <action>' calls work the same on the CLI, but in practice could do very different things.

While I got the salt-stack scripts to 'work', there are still some fixes needed. after seeing the support issues for systemd on 15.04 with salt, I decided not to include them, as it might very well take a new repo to actually fix.