### PR TITLE
Make sure root can sudo without a TTY.

### DIFF
--- a/chef/cookbooks/barclamp/recipes/default.rb
+++ b/chef/cookbooks/barclamp/recipes/default.rb
@@ -18,3 +18,16 @@ class Chef::Recipe
 end
 
 Disk.update(node)
+
+directory "/etc/sudoers.d" do
+  action :create
+  mode "0750"
+end
+
+file "/etc/sudoers.d/00_root_no_tty" do
+  action :create
+  mode "0644"
+  content <<EOC
+Defaults:root !requiretty\n
+EOC
+end


### PR DESCRIPTION
Requiring one for root is rather silly, especially when fools use it in init scripts.