### PR TITLE
Proxy client parameters need to be set for the admin

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,7 +51,7 @@ node_r=('recipe[crowbar-bootstrap::ssh]'
 database_r=('recipe[crowbar-bootstrap::postgresql]'
             'recipe[crowbar-bootstrap::goiardi]')
 proxy_r=("${prefix_r[@]}"
-         'recipe[crowbar-squid]')
+         'recipe[crowbar-squid::client]')
 consul_r=('recipe[consul::start-service]')
 
 make_recipes() {

--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -25,13 +25,6 @@ online = node[:crowbar][:provisioner][:server][:online]
 proxy = node[:crowbar][:proxy][:servers].first[:url]
 webserver = node[:crowbar][:provisioner][:server][:webservers].first[:url]
 
-# Once the local proxy service is set up, we need to use it.
-proxies = {
-  "http_proxy" => "#{proxy}",
-  "https_proxy" => "#{proxy}",
-  "no_proxy" => (["127.0.0.1","::1"] + node.all_addresses.map{|a|a.network.to_s}.sort).join(",")
-}
-
 ["/etc/gemrc","/root/.gemrc"].each do |rcfile|
   template rcfile do
     source "gemrc.erb"
@@ -39,17 +32,6 @@ proxies = {
               :webserver => webserver,
               :proxy => proxy)
   end
-end
-
-# Set up proper environments and stuff
-template "/etc/environment" do
-  source "environment.erb"
-  variables(:values => proxies)
-end
-
-template "/etc/profile.d/proxy.sh" do
-  source "proxy.sh.erb"
-  variables(:values => proxies)
 end
 
 case node["platform"]

--- a/rails/app/models/barclamp_proxy/client.rb
+++ b/rails/app/models/barclamp_proxy/client.rb
@@ -1,0 +1,23 @@
+# Copyright 2015, RackN
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+class BarclampProxy::Client < Role
+
+  def sysdata(nr)
+    admin_addrs = Node.admin.collect {|a| a.network_allocations}.flatten.collect { |na| na.address.addr }
+    { :proxy => { :admin_addrs => admin_addrs } }
+  end
+
+end


### PR DESCRIPTION
node before it gets running.  Restart admin server
after setting the proxy values

Repo shouldn't play with proxy settings.  Let the client
do it.