### PR TITLE
Force faraday to use httpclient instead of net::http.

### DIFF
--- a/crowbar-node.sh
+++ b/crowbar-node.sh
@@ -69,7 +69,7 @@ if ! [[ $(ip -4 -o addr show |grep 'scope global' |grep -v ' lo' |grep -v ' dyna
     echo "Cannot find IP address for the admin node!"
     exit 1
 fi
-IPADDR="${BASH_REMATCH[1]%/*}"
+IPADDR="${BASH_REMATCH[1]}"
 echo "Using $IPADDR for this host"
 
 # Add node to OpenCrowbar

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -44,6 +44,7 @@ gem 'chef', "~> 12.3"
 gem 'open4'
 gem 'structurematch', '~> 0.1.1'
 gem 'diplomat'
+gem 'httpclient'
 
 group :development, :test do
   gem 'coveralls'

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
   gem "factory_girl"
   gem "factory_girl_rails"
   gem 'faker'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '=3.2.1'
   gem "email_spec"
   gem "database_cleaner"
   gem "launchy"

--- a/rails/config/database.yml
+++ b/rails/config/database.yml
@@ -2,6 +2,8 @@
 # Silly code to make sure that we have access to libs
 require 'ostruct'
 require "#{`pwd`.strip}/lib/consul_access.rb"
+require 'httpclient'
+Faraday.default_adapter = :httpclient
 
 db = ConsulAccess.getService('crowbar-database')
 

--- a/rails/config/database.yml.travis
+++ b/rails/config/database.yml.travis
@@ -1,3 +1,8 @@
+<%
+# Silly code to make sure that we have access to libs
+require 'httpclient'
+Faraday.default_adapter = :httpclient
+%>
 base: &default
   adapter: postgresql
   username: postgres

--- a/rails/lib/consul_access.rb
+++ b/rails/lib/consul_access.rb
@@ -16,26 +16,6 @@
 
 class ConsulAccess
 
-  # We assume that consul is running locally.
-  # The proxy configuration may get in the way and prevent access.
-  # Force the rails app to not use a proxy to talk to the local
-  # consul agent or any agent really
-  def self.my_faraday_connection
-    conn = Faraday.new(:url => Diplomat.configuration.url, :proxy => {
-                                                             :uri      => '',
-                                                             :user     => '',
-                                                             :password => ''
-                                                         }) do |faraday|
-      faraday.request  :url_encoded
-      Diplomat.configuration.middleware.each do |middleware|
-        faraday.use middleware
-      end
-      faraday.adapter  Faraday.default_adapter
-      faraday.use      Faraday::Response::RaiseError
-    end
-    conn
-  end
-
   # TODO: One day, we should update Diplomat to take token as an option.
   # This will allow for running as non-master token and do lookups per token.
 
@@ -44,7 +24,7 @@ class ConsulAccess
     if Diplomat.configuration.acl_token.nil? and File.exists?('/etc/crowbar.master.acl')
       Diplomat.configuration.acl_token = File.read('/etc/crowbar.master.acl').chomp
     end
-    Diplomat::Service.new(my_faraday_connection).get(service_name, scope, options, meta)
+    Diplomat::Service.get(service_name, scope, options, meta)
   end
 
   # Wrap the Diplomat access to set common config/values
@@ -52,7 +32,7 @@ class ConsulAccess
     if Diplomat.configuration.acl_token.nil? and File.exists?('/etc/crowbar.master.acl')
       Diplomat.configuration.acl_token = File.read('/etc/crowbar.master.acl').chomp
     end
-    Diplomat::Kv.new(my_faraday_connection).get(key)
+    Diplomat::Kv.get(key)
   end
 
 end


### PR DESCRIPTION
httpclient supports no_proxy and allows chef and diplomat
to work properly with no_proxy set correctly.