### PR TITLE
Add class function that takes the audit table and dumps it to AMQP

### DIFF
--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -157,10 +157,14 @@ ip_re='([0-9a-f.:]+/[0-9]+)'
 
 # Add required or desired services
 services=(proxy-service dns-service ntp-service dns-mgmt_service provisioner-service
-          crowbar-api_service crowbar-job_runner_service amqp-service)
+          crowbar-api_service crowbar-job_runner_service)
 for role in "${services[@]}"; do
     crowbar nodes bind "system-phantom.internal.local" to "$role"
 done
+
+# Add this if you are going to have events sent to an AMQP service
+#crowbar nodes bind "system-phantom.internal.local" to "amqp-service"
+
 crowbar nodes set "system-phantom.internal.local" attrib dns-domain to "{ \"value\": \"$DOMAINNAME\" }"
 
 crowbar nodes commit "system-phantom.internal.local"
@@ -210,7 +214,15 @@ crowbar nodes bind "$FQDN" to crowbar-build-root-key
 crowbar nodes bind "$FQDN" to crowbar-api_server
 crowbar nodes bind "$FQDN" to crowbar-job_runner
 
-crowbar nodes bind "$FQDN" to rabbitmq-server
+#
+# Add if you wish to have an AMQP server running
+#
+#crowbar nodes bind "$FQDN" to rabbitmq-server
+#
+# Or to inject a service
+#
+#curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "209.18.47.61", "Service": {"Service": "amqp-service", "Port": 5672, "Address": "209.18.47.61", "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
+#
 
 # TODO: One day do it this way:
 # Setup DNS Server and Mgmt Shim for our own DNS Server

--- a/doc/deployment-guide/external-services.md
+++ b/doc/deployment-guide/external-services.md
@@ -71,3 +71,25 @@ By Default OpenCrowbar will install a Proxy server on the Admin server in order 
 *   Find the line 'curl -X PUT -d '{"Datacenter": "dc1", "Node": "external", "Address": "192.168.124.9", "Service": {"Service": "proxy-service", "Port": 3128, "Tags": [ "system" ]} }' http://127.0.0.1:8500/v1/catalog/register
 ` uncomment it by removing the # from the front of the line and then change the IP address of the proxy server (192.168.124.9 in this example) as well as the port (3128 in this example) to the IP and port of the proxy server for the enviornment.
 *  Save the file and continue on with the remainder of the installation steps.
+
+### AMQP Server and Service
+
+Optionally, OpenCrowbar can be configured to send events to an AMQP server through the AMQP service.  To do this, either OpenCrowbar
+should run its own RabbitMQ server or a AMQP service can be injected into OpenCrowbar.  The system currently assumes a user of *crowbar*,
+a password of *crowbar*, and a virtual host of */opencrowbar*.  
+
+To run a RabbitMQ service, uncomment the rabbitmq-server line in crowbar-config.sh.
+
+To inject an AMQP service instead, uncomment the curl line for consul.  It is next to the rabbitmq-server line.  
+
+In either case, the amqp-service needs to be enabled.  Uncomment the amqp-service crowbar bind command.
+
+Once the system is operational and the services configured, you will need to start the audit-to-event program.  To do this,
+you will need to run the following command as *crowbar* from the */opt/opencrowbar/core/rails* directory:
+RAILS_ENV=production bundle exec rake audits.to_amqp &
+
+To see events as they happen, a sample client can be run as *crowbar* from the */opt/opencrowbar/core/rails* directory:
+RAILS_ENV=production bundle exec scripts/event_client.rb \#
+
+The command line arguments are filters.  \# means all.  Node.create will return events when nodes are created.  Other options 
+are available.

--- a/rails/Rakefile
+++ b/rails/Rakefile
@@ -12,3 +12,12 @@ task :travis => ["db:drop", "railties:install:migrations", "db:migrate", "db:fix
 
 end
 
+namespace :audits do
+  task :to_amqp => :environment do
+    AuditActions.to_amqp
+  end
+
+  task :purge => :environment do
+    AuditActions.purge
+  end
+end

--- a/rails/app/models/audit_tracker.rb
+++ b/rails/app/models/audit_tracker.rb
@@ -1,0 +1,18 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class AuditTracker < ActiveRecord::Base
+
+end

--- a/rails/db/migrate/20150619171000_add_audit_track.rb
+++ b/rails/db/migrate/20150619171000_add_audit_track.rb
@@ -1,0 +1,26 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class AddAuditTrack < ActiveRecord::Migration
+  def self.up
+    create_table "audit_trackers" do |t|
+      t.string       :tracker,       index: { unique: true }
+      t.integer      :processed,     default: 0
+    end
+  end
+
+  def self.down
+    drop_table "audit_trackers"
+  end
+end

--- a/rails/lib/audit_actions.rb
+++ b/rails/lib/audit_actions.rb
@@ -1,0 +1,73 @@
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+class AuditActions
+
+  # Audit looks like this:
+  # id:              int    # database index
+  # auditable_id:    int    # Not sure - seems like index
+  # auditable_type:  string # Class audited
+  # associated_id:   int    # parent id of association
+  # associated_type: string # Class of associated type
+  # user_id:         int    # Id of user taking action
+  # user_type:       string # Class?
+  # username:        string # Name of user taking action
+  # action:          string # "create", "update", "destroy"
+  # audit_changes:   hash   # values that changed in action
+  # version:         int    # version of object at time of change
+  # comment:         string # Comment on what change if provided
+  # remote_address:  ??     # ??
+  # request_uuid:    string # uuid representing action (chains audits together)
+  # created_at:      time   # creation time
+  def self.to_amqp
+
+    # Make sure there an instance of me in the table.
+    AuditTracker.transaction do
+      AuditTracker.create!(tracker: 'AMQP') unless AuditTracker.find_by_tracker('AMQP')
+    end
+
+    # Run forever spewing events
+    while true do
+      audit = nil
+      AuditTracker.transaction do
+        me = AuditTracker.find_by_tracker('AMQP')
+
+        audit = Audited::Adapters::ActiveRecord::Audit.unscoped.where("id > ?", me.processed).limit(1).order("id ASC").first
+        if audit
+          Publisher::publish_event(audit.auditable_type, audit.action, audit)
+          me.processed = audit.id
+          me.save!
+        end
+      end
+      sleep(5) unless audit
+    end
+  end
+
+  def self.purge
+    last_seen_by_all = AuditTracker.order("processed ASC").first.processed rescue 0
+
+    count = 0
+    time = Time.now - 7.days
+    # Only destroy things older than 30 days and seen by all trackers.
+    Audited::Adapters::ActiveRecord::Audit.unscoped.where("id <= ? AND created_at < ?", last_seen_by_all, time).each do |audit|
+      audit.destroy!
+      count += 1
+    end
+
+    puts "Purged #{count} entries"
+  end
+
+end

--- a/rails/script/event_client.rb
+++ b/rails/script/event_client.rb
@@ -18,8 +18,9 @@
 require 'bunny'
 require 'json'
 require 'diplomat'
-require '/opt/opencrowbar/core/rails/lib/consul_access'
-require '/opt/opencrowbar/core/rails/lib/ip'
+
+require File.expand_path('../../lib/consul_access',  __FILE__)
+require File.expand_path('../../lib/ip',  __FILE__)
 
 if ARGV.empty?
   abort "Usage: #{$0} [binding key]"


### PR DESCRIPTION
This function can be run from multiple locations and stopped/started
without loss of sending events.  Worst case is events get sent twice.

The AMQP events can be seen by running as crowbar from
/opt/opencrowbar/core/rail:
bundle exec scripts/event_client.rb \#

This will dump all events as they are received.

Add class function that purges audits that are 7 days old and published
by all trackers.

Add rake tasks to run these actions.  audits:to_amqp and audits:purge

Neither action is run automatically.

A future item would be to run the purge as a cron entry.
A future item would be to automatically run the to_amqp function.