### PR TITLE
Allow IPv6 to be turned off.  Default it to on for admin

### DIFF
--- a/BDD/features/network.feature
+++ b/BDD/features/network.feature
@@ -23,7 +23,7 @@ Feature: Networks
     Then the {object:network} is properly formatted
 
   Scenario: Auto v6 sets range
-    When I use the Network API to create "v6a" with range "bar2" from "10.10.14.200/24" to "10.10.14.201/24"
+    When I use the Network API to create "v6a" with v6prefix of "auto"
     Then the {object:network} is properly formatted
       And key "v6prefix" should not be "auto"
       And key "v6prefix" should match "([a-f0-9]){1,4}:([a-f0-9]){1,4}:([a-f0-9]){1,4}:([a-f0-9]){1,4}"
@@ -41,8 +41,7 @@ Feature: Networks
     Given I use the Network API to create "foo1" with range "bar1" from "10.10.14.100/24" to "10.10.14.200/24"
     When REST gets the {object:network} "foo1" 
     Then key "name" should be "foo1"
-      And key "v6prefix" should not be "auto"
-      And key "v6prefix" should match "([a-f0-9]){1,4}:([a-f0-9]){1,4}:([a-f0-9]){1,4}:([a-f0-9]){1,4}"
+      And key "v6prefix" should be "null"
     Finally REST removes the {object:network} "foo1"
 
   Scenario: Install API Call Works Range

--- a/crowbar-config.sh
+++ b/crowbar-config.sh
@@ -90,6 +90,7 @@ admin_net='
   "group": "internal",
   "deployment": "system",
   "conduit": "1g0",
+  "v6prefix": "auto",
   "ranges": [
     {
       "name": "admin",

--- a/rails/app/controllers/networks_controller.rb
+++ b/rails/app/controllers/networks_controller.rb
@@ -46,7 +46,6 @@ class NetworksController < ::ApplicationController
     params[:configure] = true unless params.key?(:configure)
     params[:deployment_id] = Deployment.find_key(params[:deployment]).id if params.has_key? :deployment
     params[:deployment_id] ||= 1
-    params[:v6prefix] ||= Network::V6AUTO
     params.require(:name)
     params.require(:conduit)
     params.require(:deployment_id)
@@ -133,7 +132,7 @@ class NetworksController < ::ApplicationController
     @network = Network.find_key(params[:id])
     # Sorry, but no changing of the admin conduit for now.
     params.delete(:conduit) if @network.name == "admin"
-    @network.update_attributes!(params.permit(:description, :vlan, :use_vlan, :use_bridge, :team_mode, :use_team, :conduit, :configure, :category, :group, :deployment_id))
+    @network.update_attributes!(params.permit(:description, :vlan, :use_vlan, :v6prefix, :use_bridge, :team_mode, :use_team, :conduit, :configure, :category, :group, :deployment_id))
     respond_to do |format|
       format.html { render :action=>:show }
       format.json { render api_show @network }


### PR DESCRIPTION
network and off for BMC network.

Also auto create the v6 range if we decide later to set
v6prefix to auto.