### PR TITLE
Annealer Retry & Retry All Button(s)

### DIFF
--- a/doc/development-guides/api/node_role.md
+++ b/doc/development-guides/api/node_role.md
@@ -28,7 +28,6 @@ by ID or under the relevant Nodes, Roles, or Deployment.
 | GET  |api/v2/node_roles/:id | Specific Item |
 | PUT  |api/v2/node_roles/:id | Update Item |
 | PUT  |api/v2/node_roles/:id/retry | Retry (sets stack back to TODO) |
-| PUT  |api/v2/node_roles/:ignored/retry?list=:id|:id|:id | Retry List of IDs (pipe deliminated) |
 | POST  |api/v2/node_roles | Create Item |
 | GET  | /api/v2/node_roles/[:node_role_id]/attribs  |  List Attribs for a specific node_role |
 | GET  | /api/v2/node_roles/[:node_role_id]/attribs/[:id]  | Show Attrib (including value) for a specific Node_Role |

--- a/doc/development-guides/api/node_role.md
+++ b/doc/development-guides/api/node_role.md
@@ -27,6 +27,8 @@ by ID or under the relevant Nodes, Roles, or Deployment.
 | GET  |api/v2/node_roles | List |
 | GET  |api/v2/node_roles/:id | Specific Item |
 | PUT  |api/v2/node_roles/:id | Update Item |
+| PUT  |api/v2/node_roles/:id/retry | Retry (sets stack back to TODO) |
+| PUT  |api/v2/node_roles/:ignored/retry?list=:id|:id|:id | Retry List of IDs (pipe deliminated) |
 | POST  |api/v2/node_roles | Create Item |
 | GET  | /api/v2/node_roles/[:node_role_id]/attribs  |  List Attribs for a specific node_role |
 | GET  | /api/v2/node_roles/[:node_role_id]/attribs/[:id]  | Show Attrib (including value) for a specific Node_Role |

--- a/doc/development-guides/api/node_role.md
+++ b/doc/development-guides/api/node_role.md
@@ -27,7 +27,9 @@ by ID or under the relevant Nodes, Roles, or Deployment.
 | GET  |api/v2/node_roles | List |
 | GET  |api/v2/node_roles/:id | Specific Item |
 | PUT  |api/v2/node_roles/:id | Update Item |
-| PUT  |api/v2/node_roles/:id/retry | Retry (sets stack back to TODO) |
+| PUT  |api/v2/node_roles/:id/retry | Retry (sets state back to TODO) |
+| PUT  |api/v2/node_roles/:id/propose | Propose (sets state to PROPOSED) |
+| PUT  |api/v2/node_roles/:id/commit | Commit (sets state to COMMIT) |
 | POST  |api/v2/node_roles | Create Item |
 | GET  | /api/v2/node_roles/[:node_role_id]/attribs  |  List Attribs for a specific node_role |
 | GET  | /api/v2/node_roles/[:node_role_id]/attribs/[:id]  | Show Attrib (including value) for a specific Node_Role |

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -137,14 +137,22 @@ class NodeRolesController < ApplicationController
 
 
   def retry
-    params[:id] ||= params[:node_role_id]
-    @node_role = NodeRole.find_key params[:id]
-    @node_role.todo!
-    respond_to do |format|
-      format.html { redirect_to node_role_path(@node_role.id) }
-      format.json { render api_show @node_role }
+    if params.key? :list
+      ids = params[:list].split "|"
+      ids.each { |nr_id| NodeRole.find_key(nr_id).todo! }
+      respond_to do |format|
+        format.html { redirect_to annealer_path }
+        format.json { ender api_index NodeRole, NodeRole.in_state(NodeRole::TODO) }
+      end
+    else
+      params[:id] ||= params[:node_role_id]
+      @node_role = NodeRole.find_key params[:id]
+      @node_role.todo!
+      respond_to do |format|
+        format.html { redirect_to node_role_path(@node_role.id) }
+        format.json { render api_show @node_role }
+      end
     end
-
   end
 
   def anneal

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -135,23 +135,13 @@ class NodeRolesController < ApplicationController
     end
   end
 
-
   def retry
-    if params.key? :list
-      ids = params[:list].split "|"
-      ids.each { |nr_id| NodeRole.find_key(nr_id).todo! }
-      respond_to do |format|
-        format.html { redirect_to annealer_path }
-        format.json { ender api_index NodeRole, NodeRole.in_state(NodeRole::TODO) }
-      end
-    else
-      params[:id] ||= params[:node_role_id]
-      @node_role = NodeRole.find_key params[:id]
-      @node_role.todo!
-      respond_to do |format|
-        format.html { redirect_to node_role_path(@node_role.id) }
-        format.json { render api_show @node_role }
-      end
+    params[:id] ||= params[:node_role_id]
+    @node_role = NodeRole.find_key params[:id]
+    @node_role.todo!
+    respond_to do |format|
+      format.html { redirect_to node_role_path(@node_role.id) }
+      format.json { render api_show @node_role }
     end
   end
 

--- a/rails/app/views/node_roles/_index.html.haml
+++ b/rails/app/views/node_roles/_index.html.haml
@@ -36,4 +36,5 @@
             .led{:class => nr_led, :title=>nr.state_name}
           %td= link_to nr.state_name, node_role_path(nr.id)
           - if nr.state == NodeRole::ERROR
-            %td= link_to t('.retry'), node_role_retry_path(nr.id), :class => 'button', :method=>:put, :'data-remote' => true
+            %td= link_to t('.retry'), "/api/v2"+node_role_path(nr.id)+"/retry", :class => 'button', :method=>:put, :'data-remote' => true
+

--- a/rails/app/views/node_roles/_index.html.haml
+++ b/rails/app/views/node_roles/_index.html.haml
@@ -10,7 +10,8 @@
         %th= t '.jig'
         %th
         %th= t '.state'
-        %th= t '.status'
+        - if list.first.state == NodeRole::ERROR
+          %th= t '.action'
     %tbody
       - list.each do |nr|
         %tr.node{ :class => cycle(:odd, :even) }
@@ -34,4 +35,5 @@
           %td
             .led{:class => nr_led, :title=>nr.state_name}
           %td= link_to nr.state_name, node_role_path(nr.id)
-          %td= nr.status
+          - if nr.state == NodeRole::ERROR
+            %td= link_to t('.retry'), node_role_retry_path(nr.id), :class => 'button', :method=>:put, :'data-remote' => true

--- a/rails/app/views/node_roles/anneal.html.haml
+++ b/rails/app/views/node_roles/anneal.html.haml
@@ -1,7 +1,12 @@
 %h1= t '.title'
 
-%h2= t '.error'
 - error = NodeRole.all_by_state(NodeRole::ERROR)
+%h2
+  = t '.error'
+  - if error.length > 0
+    - list = error.map { |nr| nr.id }.join("|")
+    %raw_button{:style => 'float:right'}
+      = link_to t('.retry'), node_role_retry_path(0, :list=>list), :class => 'button', :method=>:put
 = render :partial=>'node_roles/index', :locals => { :list => error }
 
 %h2= t '.transition'

--- a/rails/app/views/node_roles/anneal.html.haml
+++ b/rails/app/views/node_roles/anneal.html.haml
@@ -4,9 +4,9 @@
 %h2
   = t '.error'
   - if error.length > 0
-    - list = error.map { |nr| nr.id }.join("|")
+    - list = error.map { |nr| nr.id }.join(",")
     %raw_button{:style => 'float:right'}
-      = link_to t('.retry'), node_role_retry_path(0, :list=>list), :class => 'button', :method=>:put
+      = link_to_function t('.retry'), "retry_all('#{list}')", :class => 'button'
 = render :partial=>'node_roles/index', :locals => { :list => error }
 
 %h2= t '.transition'
@@ -27,5 +27,14 @@
 
   function update() {
     $.ajaxSetup({ timeout: #{current_user.settings(:ui).fast_refresh} });
+    location.reload();
+  }
+
+  function retry_all(nr_ids) {
+    var ids = nr_ids.split(",");
+    for (var id of ids) {
+      console.log("/api/v2/node_roles/"+id+"/retry");
+      $.ajax({url: "/api/v2/node_roles/"+id+"/retry", type: "PUT"})
+    };
     location.reload();
   }

--- a/rails/app/views/node_roles/show.html.haml
+++ b/rails/app/views/node_roles/show.html.haml
@@ -11,7 +11,7 @@
       = @node_role.state_name
     - if @node_role.error? || @node_role.active?
       %td{:width=>'100%', :align=>'right'}
-        = link_to t('.retry'), node_role_retry_path(@node_role.id), :class => 'button', :method=>:put
+        = link_to t('.retry'), "/api/v2"+node_role_path(@node_role.id)+"/retry.html", :class => 'button', :method=>:put
 
 - if @node_role.state == NodeRole::ERROR
   - has_hint = t(@node_role.role.name, :scope => 'node_roles.show.error_hints', :default => 'none')

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -408,6 +408,8 @@ en:
   node_roles:
     index:
       title: "Node Roles"
+      action: "Action"
+      retry: "Retry"
       <<: *deployment_common
     anneal:
       title: "Crowbar Annealer Activity Monitor"

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -415,6 +415,7 @@ en:
       title: "Crowbar Annealer Activity Monitor"
       anneal: "Run Annealer"
       step: "Single Step"
+      retry: "Retry All"
       <<: *node_role_states
     show:
       rawdata: "Raw Data (json)"

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -50,9 +50,7 @@ Crowbar::Application.routes.draw do
   resources :hammers
   resources :available_hammers
   resources :jigs
-  resources :node_roles  do
-    put :retry
-  end
+  resources :node_roles
   resources :roles
 
   resources :interfaces
@@ -131,7 +129,7 @@ Crowbar::Application.routes.draw do
   # API routes (must be json and must prefix v2)()
   scope :defaults => {:format => 'json'} do
 
-    constraints(:id => /([a-zA-Z0-9\-\.\_]*)/, :version => /v[1-9]/) do
+    constraints(:id => /([a-zA-Z0-9\-\.\_]*)/, :version => /v[2-9]/) do
 
       # framework resources pattern (not barclamps specific)
       scope 'api' do
@@ -210,10 +208,10 @@ Crowbar::Application.routes.draw do
           end
 
           resources :node_roles do
-            resources :attribs
             put :retry
             put :propose
             put :commit
+            resources :attribs
           end
           resources :roles do
             resources :attribs


### PR DESCRIPTION
1) Add a retry button to all the error node roles (shows up on annealer & node role list)
2) Add a retry all button to the annealer page using AJAX (makes 1 call per node_role)
3) fix node_role show button to use API instead of UI route

I have tweaked some of the retry buttons, since all actions should be using the API, not UI routes.

That included removing the put retry from the UI (we should be removing this generally to make the UI read only).

connect to #659 
