### PR TITLE
add monitor to menu (and some refactoring of menus)

### DIFF
--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -93,6 +93,8 @@ en:
       asset_tag: "Asset Tag"
   # Layout
   nav:
+    monitor: "Monitor"
+    monitor_description: "Track System Activity"
     nodes: "Nodes"
     nodes_description: "Infrastructure Components"
     groups: "Groups"
@@ -112,9 +114,11 @@ en:
     layercake_description: "Visualize Infrastructure in Function Layers"
 
     utils: "Utilities"
+    manage_users: "Manage Users"
+    manage_users_description: "Add, remove and edit users"
+    user_settings: "Session Settings"
+    user_settings_description: "Turn on Advanced UI Controls"
     utils_description: "Tools and System Functions "
-    util_logs: "Exported Items"
-    util_logs_description: "Download information complied for review"
     jigs: "Jigs"
     jigs_description: "Configuration Manager Plug-ins"
     hammers: "Hammers"
@@ -124,16 +128,7 @@ en:
 
     help: Help
     help_description: Help
-    wiki: Online Help
-    wiki_description: Online Help
-    docs: Documentation
-    docs_description: Documentation
 
-    users: "Users"
-    manage_users: "Manage Users"
-    manage_users_description: "Add, remove and edit users"
-    user_settings: "Session Settings"
-    user_settings_description: "Turn on Advanced UI Controls"
     sign_out: "Sign Out"
     sign_out_description: "End the current session"
 

--- a/rails/config/navigation.rb
+++ b/rails/config/navigation.rb
@@ -42,6 +42,10 @@ SimpleNavigation::Configuration.run do |navigation|
                         Deployment.all.each do |d|
                           tertiary.item nav.item.to_sym, d.name, deployment_path(d.id), {:title=>d.description }
                         end
+                      elsif nav.name.eql? 'nav.monitor'
+                        Deployment.all.each do |d|
+                          tertiary.item nav.item.to_sym, d.name, monitor_path(d.id), {:title=>d.description }
+                        end
                       end            
                     rescue
                       # each the exception in the chidlren for now
@@ -61,5 +65,3 @@ SimpleNavigation::Configuration.run do |navigation|
     primary.item :help, t('nav.help'), Rails.configuration.crowbar.docs, {:title=>t('name.help_description')}
   end
 end
-
-

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -44,7 +44,7 @@ Crowbar::Application.routes.draw do
 
   end
 
-  get "monitor(/:id)" => "deployments#monitor", :as => :monitor, constraints: {id: /\d+/}
+  get "monitor(/:id)" => "deployments#monitor", :as => :monitor
   get 'docs/eula' => 'docs#eula', as: :eula
   resources :docs, constraints: {id: /[^\?]*/}
 

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -34,6 +34,12 @@ ActiveRecord::Base.transaction do
 
   Nav.find_or_create_by(item: 'root', name: 'nav.root', description: 'nav.root_description', path: "main_app.root_path", order: 0, development: true)
 
+  # monitor
+  Nav.find_or_create_by(item: 'monitor', parent_item: 'root', name: 'nav.monitor', description: 'nav.monitor_description', path: "main_app.monitor_path('system')", order: 500)
+  Nav.find_or_create_by(item: 'monitor_child', parent_item: 'monitor', name: 'nav.monitor', description: 'nav.monitor_description', path: "main_app.monitor_path('system')", order: 1000)
+  Nav.find_or_create_by(item: 'annealer', parent_item: 'monitor', name: 'nav.annealer', description: 'nav.annealer_description', path: "main_app.annealer_path", order: 3000)
+  Nav.find_or_create_by(item: 'overview', parent_item: 'monitor', name: 'nav.layercake', description: 'nav.layercake_description', path: "main_app.layercake_path", order: 4000)
+
   # nodes
   Nav.find_or_create_by(item: 'nodes', parent_item: 'root', name: 'nav.nodes', description: 'nav.nodes_description', path: "main_app.nodes_path", order: 1000)
   Nav.find_or_create_by(item: 'nodes_child', parent_item: 'nodes', name: 'nav.nodes', description: 'nav.nodes_description', path: "main_app.nodes_path", order: 1000)
@@ -46,21 +52,14 @@ ActiveRecord::Base.transaction do
   Nav.find_or_create_by(item: 'deploy', parent_item: 'root', name: 'nav.deployments', description: 'nav.deployments_description', path: "main_app.deployments_path", order: 2000)
   Nav.find_or_create_by(item: 'deploy_child', parent_item: 'deploy', name: 'nav.deployments', description: 'nav.deployments_description', path: "main_app.deployments_path", order: 1000)
   Nav.find_or_create_by(item: 'roles', parent_item: 'deploy', name: 'nav.roles', description: 'nav.roles_description', path: "main_app.roles_path", order: 2000)
-  Nav.find_or_create_by(item: 'annealer', parent_item: 'deploy', name: 'nav.annealer', description: 'nav.annealer_description', path: "main_app.annealer_path", order: 3000)
-  Nav.find_or_create_by(item: 'overview', parent_item: 'deploy', name: 'nav.layercake', description: 'nav.layercake_description', path: "main_app.layercake_path", order: 4000)
 
   # utils
   Nav.find_or_create_by(item: 'utils', parent_item: 'root', name: 'nav.utils', description: 'nav.utils_description', path: "main_app.utils_path", order: 6000)
-  Nav.find_or_create_by(item: 'utils_child', parent_item: 'utils', name: 'nav.utils', description: 'nav.utils_description', path: "main_app.utils_path", order: 100)
-  Nav.find_or_create_by(item: 'util_index', parent_item: 'utils', name: 'nav.util_logs', description: 'nav.util_logs_description', path: "main_app.utils_path", order: 200)
+  Nav.find_or_create_by(item: 'manage_users', parent_item: 'utils', name: 'nav.manage_users', description: 'nav.manage_users_description', path: "main_app.users_path", order: 100)
+  Nav.find_or_create_by(item: 'user_settings', parent_item: 'utils', name: 'nav.user_settings', description: 'nav.user_settings_description', path: "main_app.utils_settings_path", order: 200)
   Nav.find_or_create_by(item: 'jigs', parent_item: 'utils', name: 'nav.jigs', description: 'nav.jigs_description', path: "main_app.jigs_path", order: 300)
   Nav.find_or_create_by(item: 'hammers', parent_item: 'utils', name: 'nav.hammers', description: 'nav.hammers_description', path: "main_app.available_hammers_path", order: 400)
   Nav.find_or_create_by(item: 'barclamps', parent_item: 'utils', name: 'nav.barclamps', description: 'nav.barclamps_description', path: "main_app.barclamps_path", order: 4000)
-
-  # users
-  Nav.find_or_create_by(item: 'users', parent_item: 'root', name: 'nav.users', description: 'nav.users_description', path: "main_app.users_path", order: 6000)
-  Nav.find_or_create_by(item: 'manage_users', parent_item: 'users', name: 'nav.manage_users', description: 'nav.manage_users_description', path: "main_app.users_path", order: 100)
-  Nav.find_or_create_by(item: 'user_settings', parent_item: 'users', name: 'nav.user_settings', description: 'nav.user_settings_description', path: "main_app.utils_settings_path", order: 400)
 
   # networks
   Nav.find_or_create_by(item: 'networks', parent_item: 'root', name: 'nav.networks', description: 'nav.networks_description', path: "networks_path", order: 1500)


### PR DESCRIPTION
This adds the monitor page to the menus under a new top level "monitor"
I moved the Annealer & Overview pages under monitor where they made more sense
I also moved users to Utils  (removed top level users)

Connect to #213
Signed-off-by: robhirschfeld <rob@zehicle.com>