### PR TITLE
A family page back to OpenCrowbar

### DIFF
--- a/rails/app/controllers/dashboard_controller.rb
+++ b/rails/app/controllers/dashboard_controller.rb
@@ -108,7 +108,7 @@ class DashboardController < ApplicationController
     @families = if params[:id]
       params[:id].split "|"
     else
-      ['cpu', 'memory',  'number_of_drives']
+      ['cpu_count', 'memory',  'number_of_drives']
     end
     @nodes = {}
     # this works by building a single key with all the requested attributes in order

--- a/rails/app/controllers/dashboard_controller.rb
+++ b/rails/app/controllers/dashboard_controller.rb
@@ -101,12 +101,23 @@ class DashboardController < ApplicationController
     end
   end
 
+  # group nodes into categories
   def families
-    @families = {}
+
+    # the attribs list is passed as the ID w/ pipe delimiters
+    @families = if params[:id]
+      params[:id].split "|"
+    else
+      ['cpu', 'memory',  'number_of_drives']
+    end
+    @nodes = {}
+    # this works by building a single key with all the requested attributes in order
+    # that makes it easy to sort and collect like attributes
     Node.all.each do |n|
-      f = n.family.to_s  
-      @families[f] = {:names=>[], :family=>n.family} unless @families.has_key? f
-      @families[f][:names] << {:name=>n.name, :description=>n.description, :handle=>n.name}
+      next if n.system
+      key = @families.map { |f| (n.get_attrib(f) || t("unknown")).to_s }
+      @nodes[key] ||= {}
+      @nodes[key][n.id] = n.name
     end
   end
 

--- a/rails/app/views/dashboard/families.html.haml
+++ b/rails/app/views/dashboard/families.html.haml
@@ -1,27 +1,39 @@
-%h1= t('.title')
+- attribs = Attrib.all.sort_by{ |a| a.name }
+
+%p{:style => 'float:right'}
+  = t '.add'
+  = select_tag "attrib_new", options_from_collection_for_select(attribs, "name", "name", "none"), :id=>'new_attrib'
+%h1= t '.title'
+
 
 %table.data.box
   %thead
     %tr
+      %th= t('.count')
+      - @families.each do |f|
+        %th{:style => "white-space: nowrap;"}
+          = f
+          - ff = @families.clone.delete_if{|i| i == f}.join("|")
+          = link_to image_tag("icons/delete.png"), families_path(:id=>ff)
       %th= t('.name')
-      %th= t('.units')
-      %th= t('.ram')
-      %th= t('.nics')
-      %th= t('.drives')
-      %th= t('.raid')
-      %th= t('.hardware')
-      %th= t('.cpu')
   %tbody
-    - @families.each do |n, f|
-      %tr{ :class => cycle(:odd, :even, :name => "family") }
+    - @nodes.sort_by{|k, _| k}.each do |id, node|
+      %tr{ :class => cycle(:odd, :even)}
+        %td= node.length
+        - id.each do |f|
+          %td= f rescue t('na')
         %td
-          %ul.plain
-            - f[:names].each do |node|
-              %li= link_to node[:name], node_path(node[:handle]), :title=> node[:description]
-        %td= f[:names].length
-        %td= format_memory(f[:family][:ram])
-        %td= f[:family][:nics]
-        %td= f[:family][:drives]
-        %td= f[:family][:raid]
-        %td= f[:family][:hw]
-        %td= f[:family][:cpu]
+          - node.sort.each do |id, n|
+            = link_to n, node_path(id)
+
+
+:javascript
+
+$(document).ready(function(){
+  $("#new_attrib").on("change", function() {
+    a = $("#new_attrib").find('option:selected').text();
+    console.debug(a);
+    window.location.href = "#{families_path(:id=>@families.join("|"))}|"+a;
+  })
+});
+

--- a/rails/app/views/dashboard/families.html.haml
+++ b/rails/app/views/dashboard/families.html.haml
@@ -12,7 +12,7 @@
       %th= t('.count')
       - @families.each do |f|
         %th{:style => "white-space: nowrap;"}
-          = f
+          = link_to f, attrib_path(f)
           - ff = @families.clone.delete_if{|i| i == f}.join("|")
           = link_to image_tag("icons/delete.png"), families_path(:id=>ff)
       %th= t('.name')

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -103,6 +103,8 @@ en:
     getready_description: "Single Step to Provision Discovered Nodes"
     bulk_edit: "Bulk Edit"
     bulk_edit_description: "Edit Basic Information for Multiple Nodes"
+    families: "Families"
+    families_description: "Categorize based on Attributes"
 
     deployments: "Deployments"
     deployments_description: "Orchestration Management"

--- a/rails/config/locales/crowbar/en.yml
+++ b/rails/config/locales/crowbar/en.yml
@@ -242,6 +242,11 @@ en:
       clients: "Infrastructure Clients"
       services: "Services"
       apps: "Applications"
+    families:
+      title: "Node Classifications"
+      name: "Node(s)"
+      add: "Add Class:"
+      count: "Count"
     getready:
       title: "Ready State Wizard"
       selection: "Name"

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -74,6 +74,7 @@ Crowbar::Application.routes.draw do
     get 'getready'            => 'dashboard#getready', :as => :getready
     post 'getready'           => 'dashboard#getready', :as => :post_getready
     get 'layercake'           => 'dashboard#layercake', :as => :layercake
+    get 'families(/:id)'      => 'dashboard#families', :as => :families
   end
   
   # UI only functionality to help w/ visualization

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -43,6 +43,7 @@ ActiveRecord::Base.transaction do
   # nodes
   Nav.find_or_create_by(item: 'nodes', parent_item: 'root', name: 'nav.nodes', description: 'nav.nodes_description', path: "main_app.nodes_path", order: 1000)
   Nav.find_or_create_by(item: 'nodes_child', parent_item: 'nodes', name: 'nav.nodes', description: 'nav.nodes_description', path: "main_app.nodes_path", order: 1000)
+  Nav.find_or_create_by(item: 'families', parent_item: 'nodes', name: 'nav.families', description: 'nav.families_description', path: "main_app.families_path", order: 1500)
   Nav.find_or_create_by(item: 'groups', parent_item: 'nodes', name: 'nav.groups', description: 'nav.groups_description', path: "main_app.nodes_path", order: 2000, development: true)
   Nav.find_or_create_by(item: 'getready', parent_item: 'nodes', name: 'nav.getready', description: 'nav.getready_description', path: "main_app.getready_path", order: 3000)
   Nav.find_or_create_by(item: 'bulk_edit', parent_item: 'nodes', name: 'nav.bulk_edit', description: 'nav.bulk_edit_description', path: "main_app.bulk_edit_path", order: 4000)


### PR DESCRIPTION
The families page was there BUT not working - this fixes the families page!

By default, cpu_count, drive_count and ram are selected.  Users can change or add dynamically

This adds family back to the nodes menu.

No other pages are impacted by this change.

Signed-off-by: robhirschfeld <rob@zehicle.com>