### PR TITLE
Add universal simple object matching to the Crowbar API.

### DIFF
--- a/bin/crowbar
+++ b/bin/crowbar
@@ -380,6 +380,12 @@ class CrowbarProxy
     self.new(obj)
   end
 
+  def self.match_Json(data, *rest)
+    objs, res = REST.post("#{path}/match",data)
+    maybe_json_die(objs,res)
+    objs.map{|o| self.new(o)}
+  end
+
   # Spit out basic help for CRUD operations on this thing.
   def self.help
     STDERR.puts "Commands for #{apiname}:"
@@ -393,6 +399,7 @@ class CrowbarProxy
   def self.commands
     res = []
     res << Command.new(self.method(:list),self)
+    res << Command.new(self.method(:match_Json),self)
     res << Command.new(self.method(:create_Json),self)
     res << Command.new(self.method(:help),self)
     # We generate commands for any instance methods that start with do_

--- a/rails/app/controllers/attribs_controller.rb
+++ b/rails/app/controllers/attribs_controller.rb
@@ -15,6 +15,15 @@
 #
 class AttribsController < ApplicationController
 
+  def match
+    attrs = Attrib.attribute_names.map{|a|a.to_sym}
+    objs = Attrib.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index :attrib, objs.as_json }
+    end
+  end
+
   def index
     target = find_target
     @list = target.nil? ? Attrib.all : target.attribs

--- a/rails/app/controllers/available_hammers_controller.rb
+++ b/rails/app/controllers/available_hammers_controller.rb
@@ -14,6 +14,15 @@
 #
 #
 class AvailableHammersController < ApplicationController
+  
+  def match
+    attrs = AvailableHammer.attribute_names.map{|a|a.to_sym}
+    objs = AvailableHammer.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index AvailableHammer, objs }
+    end
+  end
 
   # API GET /api/v2/available_hammers
   def index

--- a/rails/app/controllers/barclamps_controller.rb
+++ b/rails/app/controllers/barclamps_controller.rb
@@ -17,6 +17,15 @@ class BarclampsController < ApplicationController
 
   self.help_contents = Array.new(superclass.help_contents)
 
+  def match
+    attrs = Barclamp.attribute_names.map{|a|a.to_sym}
+    objs = Barclamp.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Barclamp, objs }
+    end
+  end
+  
   def index
     @list = Barclamp.all
     respond_to do |format|

--- a/rails/app/controllers/deployment_roles_controller.rb
+++ b/rails/app/controllers/deployment_roles_controller.rb
@@ -15,6 +15,15 @@
 
 class DeploymentRolesController < ApplicationController
 
+  def match
+    attrs = DeploymentRole.attribute_names.map{|a|a.to_sym}
+    objs = DeploymentRole.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index DeploymentRole, objs }
+    end
+  end
+  
   def index
     @list = if params.has_key? :deployment_id
               Deployment.find_key(params[:deployment_id]).deployment_roles

--- a/rails/app/controllers/deployments_controller.rb
+++ b/rails/app/controllers/deployments_controller.rb
@@ -15,6 +15,15 @@
 #
 class DeploymentsController < ApplicationController
 
+  def match
+    attrs = Deployment.attribute_names.map{|a|a.to_sym}
+    objs = Deployment.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Deployment, objs }
+    end
+  end
+  
   def index
     @list = Deployment.order("id DESC").all
     respond_to do |format|

--- a/rails/app/controllers/dns_name_entries_controller.rb
+++ b/rails/app/controllers/dns_name_entries_controller.rb
@@ -15,6 +15,15 @@
 class DnsNameEntriesController < ::ApplicationController
   respond_to :html, :json
 
+  def match
+    attrs = DnsNameEntry.attribute_names.map{|a|a.to_sym}
+    objs = DnsNameEntry.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index DnsNameEntry, objs }
+    end
+  end
+  
   def show
     @entry = DnsNameEntry.find_key params[:id]
     respond_to do |format|

--- a/rails/app/controllers/dns_name_filters_controller.rb
+++ b/rails/app/controllers/dns_name_filters_controller.rb
@@ -15,6 +15,15 @@
 class DnsNameFiltersController < ::ApplicationController
   respond_to :html, :json
 
+  def match
+    attrs = DnsNameFilter.attribute_names.map{|a|a.to_sym}
+    objs = DnsNameFilter.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index DnsNameFilter, objs }
+    end
+  end
+  
   def show
     @filter = DnsNameFilter.find_key params[:id]
     respond_to do |format|

--- a/rails/app/controllers/hammers_controller.rb
+++ b/rails/app/controllers/hammers_controller.rb
@@ -15,7 +15,15 @@
 #
 class HammersController < ApplicationController
 
-
+  def match
+    attrs = Hammer.attribute_names.map{|a|a.to_sym}
+    objs = Hammer.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Hammer, objs }
+    end
+  end
+  
   # API GET /api/v2/hammers
   def index
     @hammers = if params.has_key?(:node_id)

--- a/rails/app/controllers/interfaces_controller.rb
+++ b/rails/app/controllers/interfaces_controller.rb
@@ -15,6 +15,15 @@
 class InterfacesController < ::ApplicationController
   respond_to :html, :json
 
+  def match
+    attrs = Interface.attribute_names.map{|a|a.to_sym}
+    objs = Interface.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Interface, objs }
+    end
+  end
+
   def create
     pattern = params[:pattern]
     bus_order = params[:bus_order].split(" | ")

--- a/rails/app/controllers/jigs_controller.rb
+++ b/rails/app/controllers/jigs_controller.rb
@@ -15,6 +15,15 @@
 #
 class JigsController < ApplicationController
 
+  def match
+    attrs = Jig.attribute_names.map{|a|a.to_sym}
+    objs = Jig.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Jig, objs }
+    end
+  end
+  
   def index
     respond_to do |format|
       format.html { @jigs = Jig.order('"order"') } # show.html.erb

--- a/rails/app/controllers/network_allocations_controller.rb
+++ b/rails/app/controllers/network_allocations_controller.rb
@@ -15,6 +15,15 @@
 class NetworkAllocationsController < ::ApplicationController
   respond_to :json
 
+  def match
+    attrs = NetworkAllocation.attribute_names.map{|a|a.to_sym}
+    objs = NetworkAllocation.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index NetworkAllocation, objs }
+    end
+  end
+  
   def create
     params.require(:node_id)
     node = Node.find(params[:node_id])
@@ -56,7 +65,7 @@ class NetworkAllocationsController < ::ApplicationController
   end
 
   def show
-    @allocation = network.network_allocations.find_key(params[:id]) rescue nil
+    @allocation = NetworkAllocation.find_key(params[:id]) rescue nil
     respond_to do |format|
       format.html {
                     @list = [@allocation]

--- a/rails/app/controllers/network_ranges_controller.rb
+++ b/rails/app/controllers/network_ranges_controller.rb
@@ -15,6 +15,15 @@
 class NetworkRangesController < ::ApplicationController
   respond_to :json
 
+  def match
+    attrs = NetworkRange.attribute_names.map{|a|a.to_sym}
+    objs = NetworkRange.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index NetworkRange, objs }
+    end
+  end
+  
   def index
     @list = if params.has_key? :network_id or params.has_key? :network
               network =  Network.find_key params[:network_id] || params[:network]

--- a/rails/app/controllers/network_routers_controller.rb
+++ b/rails/app/controllers/network_routers_controller.rb
@@ -15,6 +15,15 @@
 class NetworkRoutersController < ::ApplicationController
   respond_to :json
 
+  def match
+    attrs = NetworkRouter.attribute_names.map{|a|a.to_sym}
+    objs = NetworkRouter.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index NetworkRouter, objs }
+    end
+  end
+  
   def index
     @list = if params.has_key? :network_id or params.has_key? :network
               network =  Network.find_key params[:network_id] || params[:network]

--- a/rails/app/controllers/networks_controller.rb
+++ b/rails/app/controllers/networks_controller.rb
@@ -16,6 +16,16 @@ class NetworksController < ::ApplicationController
   respond_to :html, :json
 
   add_help(:show,[:network_id],[:get])
+
+  def match
+    attrs = Network.attribute_names.map{|a|a.to_sym}
+    objs = Network.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Network, objs }
+    end
+  end
+
   def show
     @network = Network.find_key params[:id]
     respond_to do |format|

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -15,6 +15,15 @@
 
 class NodeRolesController < ApplicationController
 
+  def match
+    attrs = NodeRole.attribute_names.map{|a|a.to_sym}
+    objs = NodeRole.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index NodeRole, objs }
+    end
+  end
+  
   def index
     @list = (if params.key? :node_id
               Node.find_key(params[:node_id]).node_roles

--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -17,6 +17,15 @@ class NodesController < ApplicationController
 
   # API GET /crowbar/v2/nodes
   # UI GET /dashboard
+  def match
+    attrs = Node.attribute_names.map{|a|a.to_sym}
+    objs = Node.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Node, objs }
+    end
+  end
+
   def index
     @list = case
             when params.has_key?(:group_id)

--- a/rails/app/controllers/roles_controller.rb
+++ b/rails/app/controllers/roles_controller.rb
@@ -15,6 +15,15 @@
 #
 class RolesController < ApplicationController
 
+  def match
+    attrs = Role.attribute_names.map{|a|a.to_sym}
+    objs = Role.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Role, objs }
+    end
+  end
+  
   def index
     @list = if params.include? :deployment_id
               Deployment.find_key(params[:deployment_id]).roles

--- a/rails/app/controllers/runs_controller.rb
+++ b/rails/app/controllers/runs_controller.rb
@@ -16,6 +16,15 @@
 class RunsController < ApplicationController
 
   # returns all the items in the annealer queue
+  def match
+    attrs = Run.attribute_names.map{|a|a.to_sym}
+    objs = Run.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Run, objs }
+    end
+  end
+
   def index
     respond_to do |format|
       format.json { render api_index :run, Run.all }

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -18,6 +18,16 @@ class UsersController < ApplicationController
   helper_method :is_edit_mode?
 
   add_help(:index,[],[:get])
+
+  def match
+    attrs = User.attribute_names.map{|a|a.to_sym}
+    objs = User.where(params.permit(attrs))
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index User, objs }
+    end
+  end
+  
   def index
     @users = User.all
     respond_to do |format|

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -132,7 +132,7 @@ Crowbar::Application.routes.draw do
   # API routes (must be json and must prefix v2)()
   scope :defaults => {:format => 'json'} do
 
-    constraints(:id => /([a-zA-Z0-9\-\.\_]*)/, :version => /v[2-9]/) do
+    constraints(:id => /([a-zA-Z0-9\-\.\_]*)/, :api_version => /v[2-9]/) do
 
       # framework resources pattern (not barclamps specific)
       scope 'api' do
@@ -145,13 +145,28 @@ Crowbar::Application.routes.draw do
         scope 'test' do
           put "nodes(/:id)" => "nodes#test_load_data"
         end
-        scope ':version' do
+        scope ':api_version' do
           # These are not restful.  They poke the annealer and wait if you pass "sync=true".
           get "anneal", :to => "node_roles#anneal", :as => :anneal
-          resources :attribs, :as=>:attribs_api
-          resources :available_hammers
-          resources :barclamps
+          resources :attribs, :as=>:attribs_api do
+            collection do
+              post 'match'
+            end
+          end
+          resources :available_hammers do
+            collection do
+              post 'match'
+            end
+          end
+          resources :barclamps do
+            collection do
+              post 'match'
+            end
+          end
           resources :deployment_roles do
+            collection do
+              post 'match'
+            end
             resources :roles
             resources :nodes
             resources :attribs
@@ -159,6 +174,9 @@ Crowbar::Application.routes.draw do
             put :commit
           end
           resources :deployments do
+            collection do
+              post 'match'
+            end
             resources :node_roles
             resources :deployment_roles
             resources :roles
@@ -176,6 +194,9 @@ Crowbar::Application.routes.draw do
           end
 
           resources :networks do
+            collection do
+              post 'match'
+            end
             resources :network_ranges
             resources :network_routers
             resources :network_allocations
@@ -187,17 +208,50 @@ Crowbar::Application.routes.draw do
             end
           end
           resources :network_ranges do
+            collection do
+              post 'match'
+            end
             resources :network_allocations
           end
-          resources :network_routers
-          resources :network_allocations
-          resources :dns_name_filters
-          resources :dns_name_entries
-          resources :interfaces
-
-          resources :runs
-          resources :jigs
+          resources :network_routers do
+            collection do
+              post 'match'
+            end
+          end
+          resources :network_allocations do
+            collection do
+              post 'match'
+            end
+          end
+          resources :dns_name_filters do
+            collection do
+              post 'match'
+            end
+          end
+          resources :dns_name_entries do
+            collection do
+              post 'match'
+            end
+          end
+          resources :interfaces do
+            collection do
+              post 'match'
+            end
+          end
+          resources :runs do
+            collection do
+              post 'match'
+            end
+          end
+          resources :jigs do
+            collection do
+              post 'match'
+            end
+          end
           resources :nodes do
+            collection do
+              post 'match'
+            end
             resources :node_roles
             resources :hammers
             resources :attribs
@@ -212,22 +266,33 @@ Crowbar::Application.routes.draw do
             get 'addresses'
           end
           resources :hammers do
+            collection do
+              post 'match'
+            end
             post :perform
           end
-
           resources :node_roles do
+            collection do
+              post 'match'
+            end
             put :retry
             put :propose
             put :commit
             resources :attribs
           end
           resources :roles do
+            collection do
+              post 'match'
+            end
             resources :attribs
             resources :deployment_roles
             resources :node_roles
             resources :nodes
           end
           resources :users do
+            collection do
+              post 'match'
+            end
             post "admin", :controller => "users", :action => "make_admin"
             delete "admin", :controller => "users", :action => "remove_admin"
             post "lock", :controller => "users", :action => "lock"


### PR DESCRIPTION
Each controller grew a "match" POST route.  If you POST a JSON blob to
the route, it will return all the objects that match the attributes
passed in the blob.  The matching performed is simple equality

Despite the choice of verb, nothing is modified on the server side -- I
just needed a verb that expects a body, as the JSON can be arbitrarily
complex and thus not really passable in URL parameters.