### PR TITLE
Fix up UI fallout from renaming :version in the routes to :api_version.

### DIFF
--- a/rails/app/views/attribs/_default.html.haml
+++ b/rails/app/views/attribs/_default.html.haml
@@ -1,5 +1,5 @@
 - value = Attrib.get(attrib.name, obj)
-= form_for :attrib, :remote => true, :url => attribs_api_path(:id=>attrib.id, obj_type=>obj.id, :version=>'v2'), :html => { :method=>:put, :'data-type' => 'html',  :class => "formtastic" } do |f|
+= form_for :attrib, :remote => true, :url => attribs_api_path(:id=>attrib.id, obj_type=>obj.id, :api_version=>'v2'), :html => { :method=>:put, :'data-type' => 'html',  :class => "formtastic" } do |f|
   %tr.node{ :class => cycle(:odd, :even) }
     %td= link_to attrib.name_i18n, attrib_path(attrib.id), :title=>attrib.description
     - if editable and attrib.writable

--- a/rails/app/views/barclamp_network/attribs/_interface_map.html.haml
+++ b/rails/app/views/barclamp_network/attribs/_interface_map.html.haml
@@ -1,6 +1,6 @@
 - value_raw = Attrib.get(attrib.name, obj)
 - value = value_raw.map { |iface| iface["pattern"] }.join ","
-= form_for :attrib, :remote => true, :url => attribs_api_path(:id=>attrib.id, obj_type=>obj.id, :version=>'v2'), :html => { :method=>:put, :'data-type' => 'html',  :class => "formtastic" } do |f|
+= form_for :attrib, :remote => true, :url => attribs_api_path(:id=>attrib.id, obj_type=>obj.id, :api_version=>'v2'), :html => { :method=>:put, :'data-type' => 'html',  :class => "formtastic" } do |f|
   %tr
     %td= link_to attrib.name_i18n, attrib_path(attrib.id), :title=>attrib.description
     %td= value

--- a/rails/app/views/barclamp_provisioner/attribs/_target_os.html.haml
+++ b/rails/app/views/barclamp_provisioner/attribs/_target_os.html.haml
@@ -2,7 +2,7 @@
 - admin = Node.admin.where(:available => true).first
 - available_os = Attrib.get("provisioner-available-oses", admin).map{ |k,v| k } rescue []
 - raw_options = 
-= form_for :attrib, :remote => true, :url => attribs_api_path(:id=>attrib.id, obj_type=>obj.id, :version=>'v2'), :html => { :method=>:put, :'data-type' => 'html',  :class => "formtastic" } do |f|
+= form_for :attrib, :remote => true, :url => attribs_api_path(:id=>attrib.id, obj_type=>obj.id, :api_version=>'v2'), :html => { :method=>:put, :'data-type' => 'html',  :class => "formtastic" } do |f|
   %tr
     %td= link_to attrib.name_i18n, attrib_path(attrib.id), :title=>attrib.description
     - if editable

--- a/rails/app/views/deployment_roles/show.html.haml
+++ b/rails/app/views/deployment_roles/show.html.haml
@@ -2,9 +2,9 @@
   = t '.title'
   = link_to @deployment_role.deployment.name, deployment_path(@deployment_role.deployment.id)
   = link_to @deployment_role.role.name_i18n, role_path(@deployment_role.role.id)
-  = link_to "Destroy", deployment_role_path(@deployment_role.id, :version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy deployment #{@deployment_role.deployment.name} role data for #{@deployment_role.role.name}?" }
+  = link_to "Destroy", deployment_role_path(@deployment_role.id, :api_version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy deployment #{@deployment_role.deployment.name} role data for #{@deployment_role.role.name}?" }
   - if @deployment_role.proposed?
-    = link_to t('.commit'), deployment_role_commit_path(@deployment_role.id, :version=>2), :class => 'button', :method=>:put
+    = link_to t('.commit'), deployment_role_commit_path(@deployment_role.id, :api_version=>2), :class => 'button', :method=>:put
   - if @deployment_role.committed?
     = link_to t('.propose'), deployment_role_propose_path(:deployment_role_id=>@deployment_role.id), :class => 'button', :method=>:put
 

--- a/rails/app/views/deployments/_buttons.html.haml
+++ b/rails/app/views/deployments/_buttons.html.haml
@@ -1,7 +1,7 @@
-= link_to "Destroy", deployment_path(deployment.id, :version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy deployment #{deployment.name}?" }
+= link_to "Destroy", deployment_path(deployment.id, :api_version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy deployment #{deployment.name}?" }
 - case
   - when deployment.proposed?
-    = link_to t('.commit'), deployment_commit_path(deployment.id, :version=>2), :class => 'button', :method=>:put
+    = link_to t('.commit'), deployment_commit_path(deployment.id, :api_version=>2), :class => 'button', :method=>:put
   - when deployment.proposable?
     = link_to t('.propose'), deployment_propose_path(:deployment_id=>deployment.id), :class => 'button', :method=>:put
   - when deployment.annealable? & !deployment.system

--- a/rails/app/views/deployments/show.html.haml
+++ b/rails/app/views/deployments/show.html.haml
@@ -6,7 +6,7 @@
     = render :partial => "header", :locals => { :deployment => @deployment }
     %td
       - if state == Deployment::PROPOSED
-        = form_for :add_role, :'data-remote' => true, :url => deployment_roles_path(:deployment_id=>@deployment.id, :version=>'v2'), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
+        = form_for :add_role, :'data-remote' => true, :url => deployment_roles_path(:deployment_id=>@deployment.id, :api_version=>'v2'), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
           - aroles = @deployment.available_roles
           - if current_user and current_user.settings(:ui).milestone_roles
             - aroles.keep_if {| r | r.milestone }
@@ -85,7 +85,7 @@
               - elsif state == Deployment::PROPOSED
                 - display = (dr.role.noop? ? "inline" : "none" )
                 %span{:style=>"margin-left:30%; display:#{display}"}
-                  = link_to image_tag('icons/add.png'), node_roles_path(:deployment_id=>@deployment.id, :format=>:json, :version=>'v2', :node_id=>node.id, :role_id=>dr.role.id), :'data-remote'=>true, :method=>:post, :class=>'node_role_add'
+                  = link_to image_tag('icons/add.png'), node_roles_path(:deployment_id=>@deployment.id, :format=>:json, :api_version=>'v2', :node_id=>node.id, :role_id=>dr.role.id), :'data-remote'=>true, :method=>:post, :class=>'node_role_add'
               - else
                 %span{:style=>"width:16px; margin:0px auto; text-align:center"}= "-"
   - else

--- a/rails/app/views/network_ranges/_index.html.haml
+++ b/rails/app/views/network_ranges/_index.html.haml
@@ -7,7 +7,7 @@
       %th
   %tbody
     - network.ranges.each do |range|
-      = form_for :network_range, :remote => true, :url => network_network_range_path(:id=>range.id, :network_id=>network.id, :version=>'v2'), :method=>:put, :html => { :method=>:put, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
+      = form_for :network_range, :remote => true, :url => network_network_range_path(:id=>range.id, :network_id=>network.id, :api_version=>'v2'), :method=>:put, :html => { :method=>:put, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
         %tr{ :class => cycle(:odd, :even) }
           %td= text_field_tag :name, range.name, :size => 10
           %td= text_field_tag :first, range.first, :size => 18
@@ -15,7 +15,7 @@
           %td
             %input.button{:type => "submit", :value => t('update')}
 
-    = form_for :network_range, :'data-remote' => true, :url => network_network_ranges_path(:network_id=>network.id, :version=>'v2'), :method=>:post, :html => { :method=>:post, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
+    = form_for :network_range, :'data-remote' => true, :url => network_network_ranges_path(:network_id=>network.id, :api_version=>'v2'), :method=>:post, :html => { :method=>:post, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
       %tr{ :class => cycle(:odd, :even) }
         %td
           = hidden_field_tag :network_id, network.id

--- a/rails/app/views/networks/show.html.haml
+++ b/rails/app/views/networks/show.html.haml
@@ -26,7 +26,7 @@
   - router = NetworkRouter.new 
   - router.network = @network
   - router.address = "0.0.0.0"
-  = form_for :network_router, :'data-remote' => true, :url => network_network_routers_path(:network_id=>@network.id, :version=>'v2'), :method=>:post, :html => { :method=>:post, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
+  = form_for :network_router, :'data-remote' => true, :url => network_network_routers_path(:network_id=>@network.id, :api_version=>'v2'), :method=>:post, :html => { :method=>:post, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
     %dl
       %dt= t '.address'
       %dd= text_field_tag :address, router.address, :size=>15

--- a/rails/app/views/node_roles/show.html.haml
+++ b/rails/app/views/node_roles/show.html.haml
@@ -2,7 +2,7 @@
   = link_to @node_role.deployment.name, deployment_path(@node_role.deployment.id)
   = link_to @node_role.node.name, node_path(@node_role.node.id)
   = link_to @node_role.role.name_i18n, role_path(@node_role.role.id)
-  = link_to "Destroy", node_role_path(@node_role.id, :version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy #{@node_role.node.name} node data for #{@node_role.role.name}?" }
+  = link_to "Destroy", node_role_path(@node_role.id, :api_version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy #{@node_role.node.name} node data for #{@node_role.role.name}?" }
 %table.plane
   %tr
     %td

--- a/rails/app/views/nodes/_show.html.haml
+++ b/rails/app/views/nodes/_show.html.haml
@@ -16,7 +16,7 @@
       = t (@node.alive ? ".alive" : ".dead")
       = t (@node.available ? ".available" : ".reserved")
       = NodeRole.state_name(state)
-      = link_to t((@node.available ? '.reserve' : '.release')), node_path(@node.id, :version=>'v2', :available=>!@node.available), 
+      = link_to t((@node.available ? '.reserve' : '.release')), node_path(@node.id, :api_version=>'v2', :available=>!@node.available), 
                     :method=>:put, :class=>'button', :remote=>true, :onclick=>"location.reload();"
 
 .column_50.last
@@ -39,5 +39,5 @@
     - if Rails.env.development? and Jig.active('test')
       %dt= t '.bdd_marker'
       %dd= @node.attrib_bdd_marker || t('ignore')
-    = link_to "Destroy", node_path(@node.id, :version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy #{@node.name}?" }
+    = link_to "Destroy", node_path(@node.id, :api_version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy #{@node.name}?" }
 .clear


### PR DESCRIPTION
I had to rename the former because of barclamp-import related reasons --
barclamps have a field named :version as well, and the namespace
collision in params space shoudl be avoided.