### PR TITLE
remove duplicate code from startup routines in development

### DIFF
--- a/development.sh
+++ b/development.sh
@@ -54,20 +54,6 @@ export FQDN
 ./crowbar-database.sh
 ./crowbar-core.sh "$RAILS_ENV"
 
-# we don't run crowbar-config but we do need to do some things from there
-	# Add consul to the default deployment, and make sure it uses the same
-	# acl master token and encryption key as the current running consul.
-./bin/crowbar deployments bind system to consul
-
-for k in acl_master_token encrypt datacenter domain acl_datacenter \
-                          acl_default_policy acl_down_policy config_dir; do
-    v="$(jq ".${k}" </etc/consul.d/default.json)"
-    [[ $v = null ]] && continue
-    ./bin/crowbar deployments set system attrib "consul-${k//_/-}" to "{\"value\": $v}"
-done
-
-./bin/crowbar deployments commit system
-
 # Make sure that Crowbar is running with the proper environment variables
 service crowbar stop
 service crowbar start


### PR DESCRIPTION
This code was needed while we changed around consul
@galthaus moved the code into the right place and now it's duplicated and should be removed.

Change limited to development.sh

Signed-off-by: Rob Hirschfeld <rob@rackn.com>