### PR TITLE
sort roles on deployment

### DIFF
--- a/BDD/features/deployment_role.feature
+++ b/BDD/features/deployment_role.feature
@@ -21,12 +21,5 @@ Feature: DeploymentRole
   Scenario: Deployment Role network-server page renders
     Given I am on the "deployment_roles/network-server?deployment=system" page
     Then I should see a heading {bdd:crowbar.i18n.deployment_roles.show.attribs}
-      And I should see {bdd:crowbar.i18n.common.roles.network-server} 
-      And there are no localization errors
-
-  Scenario: Deployment Role 1 page renders
-    Skip there is no guarantee that deployment role 1 is for crowbar-admin-node
-    Given I am on the "deployment_roles/1?deployment=system" page
-    Then I should see a heading {bdd:crowbar.i18n.deployment_roles.show.attribs} 
-      And I should see {bdd:crowbar.i18n.common.roles.crowbar-admin-node}
+      And I should see "network-server"
       And there are no localization errors

--- a/rails/app/models/role.rb
+++ b/rails/app/models/role.rb
@@ -183,7 +183,8 @@ class Role < ActiveRecord::Base
   end
 
   def name_i18n
-    I18n.t(name, :default=>name, :scope=>'common.roles')
+    #I18n.t(name, :default=>name, :scope=>'common.roles')
+    name.truncate(35)
   end
 
   def name_safe

--- a/rails/app/views/deployments/show.html.haml
+++ b/rails/app/views/deployments/show.html.haml
@@ -50,7 +50,7 @@
         - @roles.each do |dr|
           %th.dr{:id=>dr.id}
             %div
-              - name = dr.role.name_safe.truncate(30).html_safe
+              - name = dr.role.name_safe.html_safe
               = link_to name, deployment_role_path(dr.id), :title=>dr.role.description
     %tbody
       - @nodes.each do |node|

--- a/rails/app/views/deployments/show.html.haml
+++ b/rails/app/views/deployments/show.html.haml
@@ -7,12 +7,12 @@
     %td
       - if state == Deployment::PROPOSED
         = form_for :add_role, :'data-remote' => true, :url => deployment_roles_path(:deployment_id=>@deployment.id, :api_version=>'v2'), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
-          - aroles = @deployment.available_roles
+          - aroles = @deployment.available_roles.sort_by{:name}
           - if current_user and current_user.settings(:ui).milestone_roles
             - aroles.keep_if {| r | r.milestone }
           - if aroles.length > 0
             = hidden_field_tag :deployment_id, @deployment.id
-            = f.collection_select :role_id, aroles, :id, :name_i18n
+            = f.collection_select :role_id, aroles, :id, :name
             %input.button{:type => "submit", :name => "add", :value => t('.add_role')}
     %td{:align=>'right'}
       %h3= t '.services'


### PR DESCRIPTION
FINALLY.... I removed the inconsistent i18n naming because they were more confusing than helpful.

Frankly, some of the roles names are not ideal but the translations were worse.

connect to #650

Signed-off-by: Rob Hirschfeld <rob@rackn.com>