### PR TITLE
Split out chef-server start-up from database so that it

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,8 +50,8 @@ node_r=('recipe[crowbar-bootstrap::ssh]'
         'recipe[crowbar-bootstrap::crowbar-user]')
 
 database_r=('recipe[crowbar-bootstrap::consul]'
-            'recipe[crowbar-bootstrap::postgresql]'
-            'recipe[crowbar-bootstrap::goiardi]')
+            'recipe[crowbar-bootstrap::postgresql]')
+chef_server_r=('recipe[crowbar-bootstrap::goiardi]')
 proxy_r=("${prefix_r[@]}"
          'recipe[crowbar-squid::client]')
 consul_r=('recipe[crowbar-bootstrap::consul]'
@@ -66,6 +66,7 @@ make_recipes() {
 prefix_recipes="$(make_recipes "${prefix_r[@]}")"
 boot_recipes="$(make_recipes "${boot_r[@]}")"
 database_recipes="$(make_recipes "${database_r[@]}")"
+chef_server_recipes="$(make_recipes "${chef_server_r[@]}")"
 proxy_recipes="$(make_recipes "${proxy_r[@]}")"
 consul_recipes="$(make_recipes "${consul_r[@]}")"
 node_recipes="$(make_recipes "${node_r[@]}")"

--- a/crowbar-chef-server.sh
+++ b/crowbar-chef-server.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2015, Greg Althaus
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+date
+
+# setup & load env info
+. ./bootstrap.sh
+
+check_hostname
+
+# install the database
+chef-solo -c /opt/opencrowbar/core/bootstrap/chef-solo.rb -o "${chef_server_recipes}"
+

--- a/production.sh
+++ b/production.sh
@@ -68,6 +68,6 @@ echo "${FQDN#*.}" > /etc/domainname
 export FQDN
 
 mkdir -p /var/log/crowbar
-for stage in boot consul database core config finish; do
+for stage in boot consul database chef-server core config finish; do
     "./crowbar-${stage}.sh" 2>&1 |tee "/var/log/crowbar/install-${stage}.log"
 done

--- a/wizard.sh
+++ b/wizard.sh
@@ -68,6 +68,6 @@ echo "${FQDN#*.}" > /etc/domainname
 export FQDN
 
 mkdir -p /var/log/crowbar
-for stage in boot consul database core config ; do
+for stage in boot consul database chef-server core config ; do
     "./crowbar-${stage}.sh" 2>&1 |tee "/var/log/crowbar/install-${stage}.log"
 done


### PR DESCRIPTION
can be retried if need be.