### PR TITLE
Add session timer for ajax calls so that we don't run sessions

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -294,6 +294,8 @@ class ApplicationController < ActionController::Base
   end
 
   def do_auth!
+    session[:marker] = "login"
+    session[:start] = Time.now
     respond_to do |format|
       format.html { authenticate_user! }
       format.json { digest_auth! }

--- a/rails/app/controllers/support_controller.rb
+++ b/rails/app/controllers/support_controller.rb
@@ -202,10 +202,15 @@ class SupportController < ApplicationController
 
   # supplies UI heartbeat information
   def heartbeat
+    if session[:marker] != params[:marker]
+      session[:marker] = params[:marker]
+      session[:start] = Time.now
+    end
+    elapsed = (Time.now - session[:start]) rescue 0
     total = NodeRole.count
     error = NodeRole.where(state: NodeRole::ERROR).count
     active = NodeRole.where(state: NodeRole::ACTIVE).count
-    render :json=>{ :active=>active, :todo=>(total-error-active), :error=>error } 
+    render :json=>{ :active=>active, :todo=>(total-error-active), :error=>error, :elapsed=>elapsed.to_i } 
   end
 
   private 

--- a/rails/app/views/dashboard/layercake.html.haml
+++ b/rails/app/views/dashboard/layercake.html.haml
@@ -29,5 +29,8 @@
 
   function update() {
     $.ajaxSetup({ timeout: #{current_user.settings(:ui).refresh} });
-    location.reload();
+      var elasped = parseInt($('span#elapsed_heartbeat').text());
+      if (elasped < 3600) {
+        location.reload();
+      }
   }

--- a/rails/app/views/dashboard/layercake.html.haml
+++ b/rails/app/views/dashboard/layercake.html.haml
@@ -32,5 +32,7 @@
       var elasped = parseInt($('span#elapsed_heartbeat').text());
       if (elasped < 3600) {
         location.reload();
+      } else {
+        console.debug("layercake no refresh: ", elasped);
       }
   }

--- a/rails/app/views/deployments/anneal.html.haml
+++ b/rails/app/views/deployments/anneal.html.haml
@@ -26,6 +26,9 @@
 :javascript
 
   function update() {
-    $.ajaxSetup({ timeout: 1000 });
-    location.reload();
+    $.ajaxSetup({ timeout: #{current_user.settings(:ui).fast_refresh} });
+      var elasped = parseInt($('span#elapsed_heartbeat').text());
+      if (elasped < 3600) {
+        location.reload();
+      }
   }

--- a/rails/app/views/deployments/show.html.haml
+++ b/rails/app/views/deployments/show.html.haml
@@ -99,9 +99,12 @@
   var height = 100;
 
   function update() {
-    $.ajaxSetup({ timeout: 1000 });
+    $.ajaxSetup({ timeout: #{current_user.settings(:ui).fast_refresh} });
     if (#{state != Deployment::PROPOSED}) {
-      location.reload();
+      var elasped = parseInt($('span#elapsed_heartbeat').text());
+      if (elasped < 3600) {
+        location.reload();
+      }
     }
   };
 

--- a/rails/app/views/layouts/application.html.haml
+++ b/rails/app/views/layouts/application.html.haml
@@ -34,6 +34,8 @@
                 %span#todo_heartbeat= ""
                 = image_tag('icons/led/error.png', :id=>"error_led", :style=>"display:none")
                 %span#error_heartbeat= ""
+                = image_tag('icons/led/wait.png', :id=>"elasped_led", :title=>"session seconds timer", :style=>"#{(current_user.settings(:ui).edge ? 'display:inline' : 'display:none')}")
+                %span#elapsed_heartbeat{:style=>"#{(current_user.settings(:ui).edge ? 'display:inline' : 'display:none')}"}= "-1"
             %nav
               = render_navigation :expand_all => true, :skip_if_empty => true
           - else
@@ -60,28 +62,46 @@
 - if current_user or session[:digest_user]
   :javascript
 
+    Elasped = 0;
+
     function heartbeat() {
-      $.ajaxSetup({ timeout: 2500 });
 
-      $.getJSON("#{heartbeat_status_path()}", function(data) {
+      if (Elasped < 60000) {
 
-        $('span#active_heartbeat').text(data['active']);
-        if (data["todo"]==0) {
-          $('span#todo_heartbeat').text("");
-          $('img#todo_led').attr('style', 'display:none');
-        } else {
-          $('span#todo_heartbeat').text(data['todo']);
-          $('img#todo_led').attr('style', 'display:inline');
-        }
-        if (data["error"]==0) {
-          $('span#error_heartbeat').text("");
-          $('img#error_led').attr('style', 'display:none');
-        } else {
-          $('span#error_heartbeat').text(data['error']);
-          $('img#error_led').attr('style', 'display:inline');
-        }
+        $.ajaxSetup({ timeout: 2500 });
 
-      });
+        $.getJSON("#{heartbeat_status_path()}?marker=#{request.original_url}", function(data) {
+
+          Elasped = parseInt(data['elapsed']);
+          $('span#elapsed_heartbeat').text(data['elapsed']);
+
+          $('span#active_heartbeat').text(data['active']);
+          if (data["todo"]==0) {
+            $('span#todo_heartbeat').text("");
+            $('img#todo_led').attr('style', 'display:none');
+          } else {
+            $('span#todo_heartbeat').text(data['todo']);
+            $('img#todo_led').attr('style', 'display:inline');
+          }
+          if (data["error"]==0) {
+            $('span#error_heartbeat').text("");
+            $('img#error_led').attr('style', 'display:none');
+          } else {
+            $('span#error_heartbeat').text(data['error']);
+            $('img#error_led').attr('style', 'display:inline');
+          }
+        });
+
+      } else {
+        // stop polling
+        $('span#todo_heartbeat').text("");
+        $('span#error_heartbeat').text("");
+        $('span#active_heartbeat').text("?");
+        $('img#todo_led').attr('style', 'display:none');
+        $('img#error_led').attr('style', 'display:none');
+        $('img#active_led').attr('style', 'display:none');
+      }
+
     }
 
     heartbeat();

--- a/rails/app/views/layouts/application.html.haml
+++ b/rails/app/views/layouts/application.html.haml
@@ -62,17 +62,16 @@
 - if current_user or session[:digest_user]
   :javascript
 
-    Elasped = 0;
-
     function heartbeat() {
 
-      if (Elasped < 60000) {
+      elasped = parseInt($('span#elapsed_heartbeat').text());
+
+      if (elasped < 3600) {
 
         $.ajaxSetup({ timeout: 2500 });
 
         $.getJSON("#{heartbeat_status_path()}?marker=#{request.original_url}", function(data) {
 
-          Elasped = parseInt(data['elapsed']);
           $('span#elapsed_heartbeat').text(data['elapsed']);
 
           $('span#active_heartbeat').text(data['active']);
@@ -96,11 +95,14 @@
         // stop polling
         $('span#todo_heartbeat').text("");
         $('span#error_heartbeat').text("");
-        $('span#active_heartbeat').text("?");
+        $('span#active_heartbeat').text("!");
+        $('img#elasped_led').attr('style', 'display:inline');
         $('img#todo_led').attr('style', 'display:none');
         $('img#error_led').attr('style', 'display:none');
         $('img#active_led').attr('style', 'display:none');
       }
+
+      //console.debug($('span#elapsed_heartbeat').text(), elasped < 3600);
 
     }
 

--- a/rails/app/views/node_roles/anneal.html.haml
+++ b/rails/app/views/node_roles/anneal.html.haml
@@ -27,8 +27,11 @@
 
   function update() {
     $.ajaxSetup({ timeout: #{current_user.settings(:ui).fast_refresh} });
-    location.reload();
-  }
+      var elasped = parseInt($('span#elapsed_heartbeat').text());
+      if (elasped < 3600) {
+        location.reload();
+      }
+    }
 
   function retry_all(nr_ids) {
     var ids = nr_ids.split(",");

--- a/rails/app/views/node_roles/index.html.haml
+++ b/rails/app/views/node_roles/index.html.haml
@@ -12,6 +12,9 @@
 :javascript
 
   function update() {
-    $.ajaxSetup({ timeout: 1000 });
-    location.reload();
+    $.ajaxSetup({ timeout: #{current_user.settings(:ui).fast_refresh} });
+      var elasped = parseInt($('span#elapsed_heartbeat').text());
+      if (elasped < 3600) {
+        location.reload();
+      }
   }

--- a/rails/app/views/node_roles/show.html.haml
+++ b/rails/app/views/node_roles/show.html.haml
@@ -62,5 +62,7 @@
 
     function update() {
       $.ajaxSetup({ timeout: #{current_user.settings(:ui).refresh} });
-      location.reload();
+      if (elasped < 3600) {
+        location.reload();
+      }
     }


### PR DESCRIPTION
forever even if the page is polling.

This approach relies on the server to track session information
because the page refreshs make it hard to persist long term
values in the browser.

Basically, the application layout hearbeat has a hidden
span value that holds the session length in seconds.

All of the screen refresh pages have been updated to check
that value before they do a refresh.  It has been hardcoded
at an hour.

You can inspect the value of the timer by turning on
the edge UI value.  that will show the session seconds in
the top right corner with a clock icon.

Connect to #756 and #752 

Signed-off-by: robhirschfeld <rob@zehicle.com>