### PR TITLE
needed python header

### DIFF
--- a/clients/ansible/inventory.py
+++ b/clients/ansible/inventory.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 # Copyright 2015, RackN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
missed this header, was needed to make files run w/o python in command.

Signed-off-by: robhirschfeld <rob@zehicle.com>